### PR TITLE
fix: Globe mode preview card appears behind buttons with insufficient padding

### DIFF
--- a/components/globe-map-view.tsx
+++ b/components/globe-map-view.tsx
@@ -415,7 +415,8 @@ const GlobeMapViewComponent = ({
       {/* Selected Post Preview Card */}
       {selectedPost && showPreviewCard && (
         <div
-          className="absolute bottom-24 left-4 right-4 z-10 max-w-md mx-auto bg-gray-900/95 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden cursor-pointer border border-amber-500/20"
+          className="absolute left-4 right-4 z-30 max-w-md mx-auto bg-gray-900/95 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden cursor-pointer border border-amber-500/20"
+          style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 120px)' }}
           onClick={() => router.push(`/post/${selectedPost.id}`)}
         >
           <div className="flex">

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -1239,7 +1239,7 @@ function MapViewComponent({
 
       {/* 3D Globe View - Always rendered for preloading, hidden when not active */}
       <div 
-        className="absolute inset-0 z-0 transition-opacity duration-300"
+        className="absolute inset-0 transition-opacity duration-300"
         style={{ 
           opacity: viewMode === "globe" ? 1 : 0,
           visibility: viewMode === "globe" ? "visible" : "hidden",


### PR DESCRIPTION
## Problem
When tapping on a post in globe mode, the preview card was:
1. Appearing behind the gift and map toggle buttons (z-index issue)
2. Too close to the bottom menu bar (padding issue)

## Solution
- Removed `z-0` from the GlobeMapView container to prevent it from creating a stacking context that traps the preview card
- Increased preview card z-index from `z-10` to `z-30` (above the buttons at `z-20`)
- Changed bottom positioning from `bottom-24` to `calc(env(safe-area-inset-bottom, 0px) + 120px)` for proper safe area handling and more vertical padding

## Changes
- `components/map-view.tsx`: Remove `z-0` from GlobeMapView container
- `components/globe-map-view.tsx`: Update preview card z-index and bottom positioning