### PR TITLE
fix: enable marker clicks on Google Maps in dashboard

### DIFF
--- a/components/donation-modal.tsx
+++ b/components/donation-modal.tsx
@@ -264,6 +264,7 @@ export function DonationModal({ open, onOpenChange, preSelectedLocation }: Donat
                 isLoading={isLoadingPosts}
                 isModal={true}
                 initialSearchQuery={locationName}
+                disableMarkerClicks={true}
               />
             </div>
 

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -57,6 +57,7 @@ interface MapViewProps {
   onNewIssue?: () => void // Optional callback for floating "+" button (desktop dashboard)
   showPreviewCard?: boolean // Whether to show the post preview card when a marker is clicked (default: true)
   hideSearchOverlay?: boolean // Hide the search bar and donate button overlay (for embedded desktop use)
+  disableMarkerClicks?: boolean // Explicitly disable marker click interactions (for donation modal)
 }
 
 // Declare google as a global type to avoid linting errors
@@ -82,6 +83,7 @@ function MapViewComponent({
   onNewIssue,
   showPreviewCard = true,
   hideSearchOverlay = false,
+  disableMarkerClicks = false,
 }: MapViewProps) {
   const router = useRouter()
   const mapRef = useRef<HTMLDivElement>(null)
@@ -878,8 +880,8 @@ function MapViewComponent({
     })
     markersRef.current = {}
 
-    // Determine if markers should be clickable (not clickable in modal/donation flow)
-    const markersClickable = !isModal
+    // Determine if markers should be clickable (explicitly disabled for donation flow)
+    const markersClickable = !disableMarkerClicks
 
     // Get current map bounds for viewport prioritization
     const bounds = map.getBounds()


### PR DESCRIPTION
## Problem
Clicking on map markers from the Google Map version of the map was not showing the preview card on the dashboard.

## Root Cause
The `isModal` prop was being reused for two different purposes:
1. **Layout control** (bottom nav spacing in dashboard side panel)
2. **Marker click control** (disabling clicks in donation modal)

When the dashboard passed `isModal={true}` for layout purposes, it inadvertently disabled all marker clicks due to this logic:
```typescript
const markersClickable = !isModal  // Bug: layout prop affecting click behavior
```

## Solution
Introduced a new explicit prop `disableMarkerClicks` to separate these concerns:
- `isModal`: controls layout/spacing only
- `disableMarkerClicks`: explicitly controls marker click interactions

**Result:**
- Dashboard: `isModal={true}`, `disableMarkerClicks=false` (default) → Markers are clickable ✓
- Donation modal: `isModal={true}`, `disableMarkerClicks={true}` → Markers stay non-clickable ✓
- Mobile map page: both default to `false` → Markers are clickable ✓