### PR TITLE
feat: improve group share UX with clickable copy fields and share buttons

### DIFF
--- a/components/create-group-dialog.tsx
+++ b/components/create-group-dialog.tsx
@@ -12,6 +12,7 @@ import { createBrowserSupabaseClient } from "@/lib/supabase"
 import { toast } from "sonner"
 import { v4 as uuidv4 } from "@/lib/uuid"
 import type { Group } from "@/lib/types"
+import { Share2 } from "lucide-react"
 
 interface CreateGroupDialogProps {
   open: boolean
@@ -24,6 +25,8 @@ export function CreateGroupDialog({ open, onOpenChange, userId, onSuccess }: Cre
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [step, setStep] = useState<"create" | "share">("create")
+  const [createdGroup, setCreatedGroup] = useState<Group | null>(null)
   const supabase = createBrowserSupabaseClient()
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -80,15 +83,13 @@ export function CreateGroupDialog({ open, onOpenChange, userId, onSuccess }: Cre
         throw memberError
       }
 
-      // Call the success callback with the new group
-      onSuccess({
+      // Store created group and show share step
+      const newGroup = {
         ...groupData,
         memberCount: 1,
-      })
-
-      // Reset form
-      setName("")
-      setDescription("")
+      }
+      setCreatedGroup(newGroup)
+      setStep("share")
     } catch (error) {
       console.error("Error creating group:", error)
       toast.error("Error", {
@@ -96,6 +97,110 @@ export function CreateGroupDialog({ open, onOpenChange, userId, onSuccess }: Cre
       })
     } finally {
       setIsSubmitting(false)
+    }
+  }
+
+  const handleContinue = () => {
+    if (createdGroup) {
+      onSuccess(createdGroup)
+    }
+    handleClose()
+  }
+
+  const handleClose = () => {
+    // Reset state when dialog closes
+    setStep("create")
+    setName("")
+    setDescription("")
+    setCreatedGroup(null)
+    onOpenChange(false)
+  }
+
+  const inviteUrl = createdGroup?.invite_code 
+    ? `https://www.ganamos.earth/groups/join/${createdGroup.invite_code}`
+    : ""
+
+  const handleCopyLink = async () => {
+    if (inviteUrl) {
+      try {
+        await navigator.clipboard.writeText(inviteUrl)
+        toast.success("Copied to clipboard", {
+          description: "Invite link copied",
+        })
+      } catch (error) {
+        console.error("Failed to copy:", error)
+      }
+    }
+  }
+
+  const handleCopyCode = async () => {
+    if (createdGroup?.group_code) {
+      try {
+        await navigator.clipboard.writeText(createdGroup.group_code)
+        toast.success("Copied to clipboard", {
+          description: "Group code copied",
+        })
+      } catch (error) {
+        console.error("Failed to copy:", error)
+      }
+    }
+  }
+
+  const handleShareLink = async () => {
+    const shareText = `Join my group "${createdGroup?.name}" on Ganamos!\n\nUse invite link: ${inviteUrl}\n\nOr enter code: ${createdGroup?.group_code}`
+    
+    // Check if it's a mobile device and supports native share
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+    
+    if (isMobile && navigator.share) {
+      try {
+        await navigator.share({
+          title: `Join ${createdGroup?.name} on Ganamos`,
+          text: shareText,
+        })
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('Error sharing:', error)
+        }
+      }
+    } else {
+      // Desktop fallback - copy to clipboard
+      try {
+        await navigator.clipboard.writeText(shareText)
+        toast.success("Copied to clipboard", {
+          description: "Share text copied - paste it in your favorite app",
+        })
+      } catch (error) {
+        console.error("Failed to copy:", error)
+      }
+    }
+  }
+
+  const handleShareCode = async () => {
+    const shareText = `Join my group "${createdGroup?.name}" on Ganamos!\n\nEnter group code: ${createdGroup?.group_code}`
+    
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+    
+    if (isMobile && navigator.share) {
+      try {
+        await navigator.share({
+          title: `Join ${createdGroup?.name} on Ganamos`,
+          text: shareText,
+        })
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('Error sharing:', error)
+        }
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(shareText)
+        toast.success("Copied to clipboard", {
+          description: "Share text copied - paste it in your favorite app",
+        })
+      } catch (error) {
+        console.error("Failed to copy:", error)
+      }
     }
   }
 
@@ -120,69 +225,173 @@ export function CreateGroupDialog({ open, onOpenChange, userId, onSuccess }: Cre
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Create New Group</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="name">Group Name</Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Enter group name"
-                required
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="description">Description (Optional)</Label>
-              <Textarea
-                id="description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Describe your group"
-                rows={3}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? (
-                <div className="flex items-center">
-                  <svg
-                    className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Creating...
+        {step === "create" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create New Group</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleSubmit}>
+              <div className="grid gap-4 py-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="name">Group Name</Label>
+                  <Input
+                    id="name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Enter group name"
+                    required
+                  />
                 </div>
-              ) : (
-                "Create Group"
-              )}
+                <div className="grid gap-2">
+                  <Label htmlFor="description">Description (Optional)</Label>
+                  <Textarea
+                    id="description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Describe your group"
+                    rows={3}
+                  />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={handleClose}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? (
+                    <div className="flex items-center">
+                      <svg
+                        className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        ></circle>
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        ></path>
+                      </svg>
+                      Creating...
+                    </div>
+                  ) : (
+                    "Create Group"
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Share {createdGroup?.name} group</DialogTitle>
+            </DialogHeader>
+            <div className="py-4 space-y-4">
+              {/* Invite Link */}
+              <div>
+                <p className="text-sm font-medium mb-2 flex items-center gap-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                  </svg>
+                  Invite Link
+                </p>
+                <div className="flex items-center space-x-2">
+                  <button
+                    type="button"
+                    onClick={handleCopyLink}
+                    className="flex-1 h-10 bg-gray-50 dark:bg-gray-800 rounded-md px-3 text-left text-sm font-mono truncate hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer border border-transparent hover:border-gray-200 dark:hover:border-gray-600"
+                  >
+                    {inviteUrl}
+                  </button>
+                  <Button 
+                    type="button"
+                    variant="outline" 
+                    size="icon" 
+                    className="h-10 w-10 shrink-0" 
+                    onClick={handleShareLink}
+                    title="Share link"
+                  >
+                    <Share2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Group Code */}
+              <div>
+                <p className="text-sm font-medium mb-2 flex items-center gap-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                    <circle cx="9" cy="7" r="4" />
+                    <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                  </svg>
+                  Group Code
+                </p>
+                <div className="flex items-center space-x-2">
+                  <button
+                    type="button"
+                    onClick={handleCopyCode}
+                    className="flex-1 h-10 bg-gray-50 dark:bg-gray-800 rounded-md flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer border border-transparent hover:border-gray-200 dark:hover:border-gray-600"
+                  >
+                    <span className="font-mono text-xl font-bold tracking-widest">
+                      {createdGroup?.group_code}
+                    </span>
+                  </button>
+                  <Button 
+                    type="button"
+                    variant="outline" 
+                    size="icon" 
+                    className="h-10 w-10 shrink-0" 
+                    onClick={handleShareCode}
+                    title="Share code"
+                  >
+                    <Share2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            {/* Continue Button - matches Start button styling */}
+            <Button 
+              type="button"
+              onClick={handleContinue}
+              className="w-full h-12 bg-green-600 hover:bg-green-700 text-white text-lg font-semibold"
+            >
+              Continue
             </Button>
-          </DialogFooter>
-        </form>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

Improves the UX of the group invite/share step after creating a group.

### Changes:
- **Two-step flow**: CreateGroupDialog now shows a share step after group creation
- **Updated header**: Changed to 'Share [Group name] group' without quotes around group name
- **Cleaner UI**: Removed 'Your group has been created' section, explainer texts, and tip section
- **Clickable fields**: Invite link and group code are now clickable buttons that copy to clipboard with a toast notification
- **Share buttons**: Replaced copy buttons with share buttons (up arrow icon) that open the native share sheet on mobile or copy formatted share text on desktop
- **Larger Continue button**: Matches the height (h-12) and font size (text-lg) of the Start button on the fix initiation step
- **Consistent experience**: Applied the same improvements to the existing share dialog on the group page

### Testing
- Create a new group and verify the share step appears with the new UI
- Test clicking the invite link and group code fields to copy
- Test the share buttons on mobile (should open native share sheet) and desktop (should copy to clipboard)
- Visit an existing group page and use the Share button to verify the dialog matches