### PR TITLE
fix: use correct param name for device list API

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -229,7 +229,7 @@ export default function ProfilePage() {
       
       setIsDevicesLoading(true);
       try {
-        const response = await fetch(`/api/device/list?userId=${activeUserId}`);
+        const response = await fetch(`/api/device/list?activeUserId=${activeUserId}`);
         const data = await response.json();
         if (data.devices) {
           setConnectedDevices(data.devices);


### PR DESCRIPTION
## Problem
The profile page was passing `userId` to the device list API, but the API expects `activeUserId`. This caused pets to not show on the profile page.

## Solution
Changed `userId` → `activeUserId` in the fetch call.

## Testing
- Device 'pup' should now appear on the profile page after this fix