### PR TITLE
fix: show new issue button on map for anonymous users

### DIFF
--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -1256,10 +1256,10 @@ function MapViewComponent({
         />
       </div>
 
-      {/* Floating New Issue Button - Only show when onNewIssue is provided (desktop dashboard) */}
-      {onNewIssue && (
+      {/* Floating New Issue Button - Always show on map (uses onNewIssue if provided, otherwise navigates to /post/new) */}
+      {!hideSearchOverlay && (
         <button
-          onClick={onNewIssue}
+          onClick={onNewIssue || handleNewPost}
           className="absolute right-6 z-20 flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:bg-primary/90 transition-all duration-200 transform hover:scale-105 shadow-lg"
           style={{ bottom: isModal ? 24 : BOTTOM_NAV_CLEARANCE }}
           aria-label="New Issue"

--- a/middleware.ts
+++ b/middleware.ts
@@ -52,7 +52,8 @@ export async function middleware(req: NextRequest) {
   }
 
   // Protected routes require authentication
-  const protectedRoutes = ["/dashboard", "/wallet", "/profile", "/post/new"]
+  // Note: /post/new is NOT protected - it supports anonymous posting with Lightning payment
+  const protectedRoutes = ["/dashboard", "/wallet", "/profile"]
   const isProtectedRoute = protectedRoutes.some((route) => path.startsWith(route))
 
   // Auth routes for redirecting authenticated users


### PR DESCRIPTION
## Problem
Anonymous users couldn't see a 'new issue' button when navigating to the map via 'Earn bitcoin' button on ganamos.earth.

## Root Cause
1. The bottom navigation (with the '+' button) is hidden for unauthenticated users
2. The floating '+' button on the map was only shown when `onNewIssue` prop was provided (desktop dashboard only)
3. The `/post/new` route was protected by middleware, redirecting anonymous users to login

## Solution
1. **map-view.tsx**: Show floating '+' button on map for all users (uses `onNewIssue` if provided, otherwise navigates to `/post/new`)
2. **middleware.ts**: Remove `/post/new` from protected routes - the page already handles anonymous users with Lightning payment flow

## Result
- **Logged-in users**: See the full bottom navigation menu (unchanged)
- **Anonymous users**: See the '+' button on the map, can click it to create and fund a post with Lightning