### PR TITLE
Fix email button text color: change link text from blue to white

### DIFF
--- a/email-templates/supabase-confirm-signup.html
+++ b/email-templates/supabase-confirm-signup.html
@@ -83,7 +83,7 @@
         Thanks for signing up. Click the button below to confirm your email address and activate your account.
       </p>
       <center>
-        <a href="{{ .ConfirmationURL }}" class="cta-button">Confirm Email</a>
+        <a href="{{ .ConfirmationURL }}" class="cta-button" style="color: #ffffff !important;">Confirm Email</a>
       </center>
       <div class="security-note">
         <strong>Security tip:</strong> If you didn't create this account, you can safely ignore this email.

--- a/email-templates/supabase-email-change.html
+++ b/email-templates/supabase-email-change.html
@@ -83,7 +83,7 @@
         Click the button below to confirm your new email address for your Ganamos account.
       </p>
       <center>
-        <a href="{{ .ConfirmationURL }}" class="cta-button">Confirm New Email</a>
+        <a href="{{ .ConfirmationURL }}" class="cta-button" style="color: #ffffff !important;">Confirm New Email</a>
       </center>
       <div class="security-note">
         <strong>Security tip:</strong> If you didn't request this email change, please contact support immediately.


### PR DESCRIPTION
Fix email button text color: change link text from blue to white

- Update supabase-confirm-signup.html to use white text color for "Confirm Email" button
- Update supabase-email-change.html to use white text color for "Confirm New Email" button
- Add inline style with !important flag to override default email client link colors
- Improves readability of white text on green gradient background

---

_View task here [cml17f4e50001le04uu7ago16](https://hive.sphinx.chat/w/ganamos-6/task/cml17f4e50001le04uu7ago16)_