### PR TITLE
fix: use fresh location for explicit Get Location button

### DIFF
--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -479,7 +479,7 @@ export default function NewPostPage() {
     // setLocationErrorCount(0) // Reset error count on new attempt - this was part of the undone change
 
     try {
-      const locationInfo = await getCurrentLocationWithName({ forceRefresh: false, useCache: true }) // Use the imported utility
+      const locationInfo = await getCurrentLocationWithName({ forceRefresh: true, useCache: false }) // User explicitly requested fresh location
 
       if (locationInfo) {
         setCurrentLocation({


### PR DESCRIPTION
## Problem
PR #20 enabled location caching for both:
1. Auto-population after photo capture
2. Explicit 'Get Location' button presses

This causes an issue where users pressing the Get Location button expect fresh GPS data, but may receive cached (potentially stale) location.

## Solution
- **Keep caching** for auto-population after photo capture (line 407) — user is at that spot, 5-min browser cache is reasonable
- **Use fresh location** for explicit button presses (line 482) — user expects current GPS when they tap the button

## Changes
One line change: `forceRefresh: true, useCache: false` for `handleGetLocation`