### PR TITLE
fix: clear localStorage cache when unpairing SatoshiPet

### DIFF
--- a/app/pet-settings/page.tsx
+++ b/app/pet-settings/page.tsx
@@ -157,6 +157,13 @@ export default function PetSettingsPage() {
         toast.success("Pet Unpaired", {
           description: "Your device has been disconnected.",
         })
+        
+        // Clear the pet cache to ensure profile page doesn't show stale data
+        const activeUserId = localStorage.getItem('ganamos_active_user_id')
+        if (activeUserId) {
+          localStorage.removeItem(`ganamos_pet_${activeUserId}`)
+        }
+        
         // Redirect to profile
         router.push('/profile')
       } else {

--- a/app/pet-settings/page.tsx
+++ b/app/pet-settings/page.tsx
@@ -159,9 +159,9 @@ export default function PetSettingsPage() {
         })
         
         // Clear the pet cache to ensure profile page doesn't show stale data
-        const activeUserId = localStorage.getItem('ganamos_active_user_id')
-        if (activeUserId) {
-          localStorage.removeItem(`ganamos_pet_${activeUserId}`)
+        const targetUserId = activeUserId || user?.id
+        if (targetUserId) {
+          localStorage.removeItem(`ganamos_pet_${targetUserId}`)
         }
         
         // Redirect to profile

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -247,6 +247,10 @@ export default function ProfilePage() {
               JSON.stringify({ pet: petData, timestamp: Date.now() })
             );
             setCachedPet(petData);
+          } else {
+            // Clear cache when no devices are connected
+            localStorage.removeItem(`${CACHE_KEYS.PET}_${targetUserId}`);
+            setCachedPet(null);
           }
       }
     } catch (error) {


### PR DESCRIPTION
fix: clear localStorage cache when unpairing SatoshiPet

- Add cache clearing in pet-settings page before redirect after successful unpair
- Add cache clearing in profile page when no devices are returned from API
- Fixes issue where unpaired pets still appeared in UI due to stale localStorage data

---

_View task here [cml4emu6b0006jl0475e9z48i](https://hive.sphinx.chat/w/ganamos-6/task/cml4emu6b0006jl0475e9z48i)_