### PR TITLE
feat: Add foundation for text-based tasks

### DIFF
--- a/app/actions/post-actions.ts
+++ b/app/actions/post-actions.ts
@@ -574,6 +574,7 @@ export async function createFundedAnonymousPostAction(postDetails: {
   city: string | null
   funding_r_hash: string // Renamed from fundingRHash
   funding_payment_request: string // Added this
+  task_type?: 'photo' | 'text' // Type of task: photo requires image proof, text requires text response
 }): Promise<{ success: boolean; postId?: string; error?: string }> {
   const supabase = createServerSupabaseClient(await getCookieStore())
   const postId = uuidv4()
@@ -621,6 +622,7 @@ export async function createFundedAnonymousPostAction(postDetails: {
         funding_r_hash: postDetails.funding_r_hash,
         funding_payment_request: postDetails.funding_payment_request,
         funding_status: "paid",
+        task_type: postDetails.task_type || 'photo', // Default to 'photo' for backward compatibility
       })
       .select("id")
       .single()

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -26,7 +26,8 @@ const DEFAULT_JOB_REWARD = 1000 // Default job reward in sats
  *   "location": "Location name", // optional
  *   "latitude": 37.7749, // optional
  *   "longitude": -122.4194, // optional
- *   "reward": 1000 // reward in sats (total payment = reward + 10 sats API fee)
+ *   "reward": 1000, // reward in sats (total payment = reward + 10 sats API fee)
+ *   "task_type": "photo" | "text" // optional, defaults to "photo"
  * }
  */
 export async function POST(request: NextRequest) {
@@ -78,7 +79,10 @@ export async function POST(request: NextRequest) {
 
     // Parse request body
     const body = await request.json()
-    const { title, description, image_url, location, latitude, longitude, reward } = body
+    const { title, description, image_url, location, latitude, longitude, reward, task_type } = body
+    
+    // Validate task_type if provided
+    const validTaskType = task_type === 'text' ? 'text' : 'photo' // Default to 'photo'
 
     // Validate required fields
     if (!description || typeof description !== 'string') {
@@ -139,7 +143,8 @@ export async function POST(request: NextRequest) {
       longitude: longitude || null,
       city: location || null, // Use location as city for now
       funding_r_hash: verification.paymentHash!,
-      funding_payment_request: '' // We don't have the original payment request, but it's paid
+      funding_payment_request: '', // We don't have the original payment request, but it's paid
+      task_type: validTaskType // 'photo' or 'text'
     })
 
     if (!postResult.success) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,7 @@ export interface Post {
   description: string
   imageUrl?: string
   image_url?: string
+  task_type?: 'photo' | 'text' // Type of task: photo requires image proof, text requires text response
   location?: string // Make optional
   latitude?: number // Add optional latitude
   longitude?: number // Add optional longitude
@@ -37,6 +38,7 @@ export interface Post {
   submitted_fix_image_url?: string | null
   fixed_image_url?: string | null
   submitted_fix_note?: string | null
+  submitted_fix_text?: string | null // Text response for text-based task submissions
   submitted_fix_lightning_address?: string | null
   city?: string | null
   ai_confidence_score?: number | null

--- a/supabase/migrations/20260206000000_add_text_task_support.sql
+++ b/supabase/migrations/20260206000000_add_text_task_support.sql
@@ -1,0 +1,18 @@
+-- Add support for text-based tasks
+-- This allows agents to complete tasks that don't require photo verification
+
+-- Add task_type column to posts (default 'photo' for backward compatibility)
+ALTER TABLE posts 
+ADD COLUMN IF NOT EXISTS task_type TEXT NOT NULL DEFAULT 'photo' 
+CHECK (task_type IN ('photo', 'text'));
+
+-- Add submitted_fix_text column for text-based submissions
+ALTER TABLE posts 
+ADD COLUMN IF NOT EXISTS submitted_fix_text TEXT;
+
+-- Add index for querying by task type
+CREATE INDEX IF NOT EXISTS idx_posts_task_type ON posts(task_type);
+
+-- Comment for documentation
+COMMENT ON COLUMN posts.task_type IS 'Type of task: photo (requires image proof) or text (requires text response)';
+COMMENT ON COLUMN posts.submitted_fix_text IS 'Text response for text-based task submissions';


### PR DESCRIPTION
## Summary
Adds database schema and API support for text-based tasks that agents can complete without photo verification.

## Example Task
```
POST /api/posts
{
  "description": "What's the current price of bitcoin in USD?",
  "reward": 100,
  "task_type": "text"
}
```

Agent completes by submitting answer via `fixer_note` field. Human poster verifies.

## Changes
- **Migration**: Adds `task_type` ('photo'|'text') and `submitted_fix_text` columns to posts
- **Types**: Updated Post interface with new fields
- **API**: `POST /api/posts` now accepts `task_type` parameter
- **Action**: `createFundedAnonymousPostAction` passes task_type to DB

## Verification Flow for Text Tasks
Text tasks skip AI image verification and go straight to human review. The poster verifies the text response is correct before releasing reward.

## Future Work (not in this PR)
- UI updates for text input on submission page
- `GET /api/posts?task_type=text` filter for agents to find completable tasks
- Structured verification for specific task types (e.g., code with tests)

## Backward Compatible
- Defaults to `task_type='photo'` so existing posts/flows unchanged
- No breaking changes to current API contracts