### PR TITLE
fix: Send empty strings to clear cached rejection on SatoshiPets

### DIFF
--- a/app/api/device/config/route.ts
+++ b/app/api/device/config/route.ts
@@ -417,12 +417,17 @@ export async function GET(request: NextRequest) {
       newJobReward: newJobReward,
     }
     
-    // Only include rejection fields if there's actually a rejection to show
-    // This prevents Arduino from displaying "Fix rejected null" when there's no rejection
+    // Always send rejection fields - empty strings when no rejection to clear Arduino's cached state
+    // Using empty strings instead of null/omitting to explicitly signal "no rejection"
     if (device.last_rejection_id) {
       config.lastRejectionId = device.last_rejection_id
       config.rejectionMessage = device.rejection_message || "Try again!"
       config.rejectionPostTitle = rejectionPostTitle || "Issue"
+    } else {
+      // Explicitly send empty strings to clear any cached rejection on the device
+      config.lastRejectionId = ""
+      config.rejectionMessage = ""
+      config.rejectionPostTitle = ""
     }
 
     // Return device configuration and user data with explicit no-cache headers


### PR DESCRIPTION
## Follow-up to PR #43

The previous fix omitted rejection fields when there was no rejection. However, the Arduino firmware caches rejection notifications locally and kept displaying the old cached value.

## Solution
Now we explicitly send **empty strings** when there's no rejection:
```json
{
  "lastRejectionId": "",
  "rejectionMessage": "",
  "rejectionPostTitle": ""
}
```

This tells the Arduino firmware to clear its cached rejection state, stopping the 'Fix rejected null' display.