### PR TITLE
fix: device update/remove APIs support connected accounts (activeUserId)

### DIFF
--- a/app/pet-settings/page.tsx
+++ b/app/pet-settings/page.tsx
@@ -100,6 +100,7 @@ export default function PetSettingsPage() {
 
     setIsSaving(true)
     try {
+      const targetUserId = activeUserId || user?.id
       const response = await fetch('/api/device/update', {
         method: 'POST',
         headers: {
@@ -109,6 +110,7 @@ export default function PetSettingsPage() {
           deviceId: device.id,
           petName: petName.trim(),
           petType,
+          activeUserId: targetUserId,
         }),
       })
 
@@ -141,6 +143,7 @@ export default function PetSettingsPage() {
 
     setIsUnpairing(true)
     try {
+      const targetUserId = activeUserId || user?.id
       const response = await fetch('/api/device/remove', {
         method: 'POST',
         headers: {
@@ -148,6 +151,7 @@ export default function PetSettingsPage() {
         },
         body: JSON.stringify({
           deviceId: device.id,
+          activeUserId: targetUserId,
         }),
       })
 


### PR DESCRIPTION
## Problem
When a user was viewing a connected account's device settings (e.g., a parent managing a child's pet), trying to update the pet name/type or unpair the device would fail with error:
```
PGRST116: JSON object requested, multiple (or no) rows returned
```

The device update returned 500 and the device remove silently failed.

## Root Cause
- `/api/device/list` correctly uses `activeUserId` to fetch devices for connected accounts
- `/api/device/update` and `/api/device/remove` were using only the authenticated user's ID (`user.id`) instead of the device owner's ID

This caused queries to match 0 rows because `user_id = authenticated_user_id` didn't match when the device belongs to a connected account.

## Solution
1. Both APIs now accept an `activeUserId` parameter
2. Both APIs verify the user has permission via `connected_accounts` table when modifying another user's device
3. `pet-settings/page.tsx` now passes `activeUserId` to both API calls

## Files Changed
- `app/api/device/update/route.ts`
- `app/api/device/remove/route.ts`
- `app/pet-settings/page.tsx`