### PR TITLE
Fix persistent location and camera permission prompts on PWA

### DIFF
--- a/app/donate/page.tsx
+++ b/app/donate/page.tsx
@@ -119,7 +119,7 @@ export default function DonatePage() {
         setIsLoadingLocations(true)
         let userLocation = undefined
         try {
-          const currentLocation = await getCurrentLocationWithName({ useCache: true })
+          const currentLocation = await getCurrentLocationWithName({ useCache: true, preferCached: true })
           if (currentLocation) {
             userLocation = {
               locality: currentLocation.locality,

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -54,7 +54,7 @@ export default function MapPage() {
 
       try {
         // Always try fresh location first, fallback to cached if available
-        const location = await getCurrentLocationWithName({ useCache: true })
+        const location = await getCurrentLocationWithName({ useCache: true, preferCached: true })
         if (location) {
           setUserLocation({
             latitude: location.latitude,

--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -407,7 +407,7 @@ export default function NewPostPage() {
     // Since the photo is being taken right now, the issue is at the user's current location
     setIsGettingLocation(true)
     try {
-      const locationInfo = await getCurrentLocationWithName({ forceRefresh: false, useCache: true })
+      const locationInfo = await getCurrentLocationWithName({ useCache: true }) // Real-time location for post precision; useCache only as fallback on error
 
       if (locationInfo) {
         setCurrentLocation({

--- a/components/camera-capture.tsx
+++ b/components/camera-capture.tsx
@@ -58,18 +58,41 @@ export function CameraCapture({
     }
   }, [])
 
-  // Helper to check if we've already been granted camera access this session
+  // Helper to check if we've already been granted camera access
+  // Uses localStorage instead of sessionStorage so permission state persists across PWA sessions
+  const CAMERA_PERMISSION_KEY = 'ganamos_camera_permission'
+  const CAMERA_PERMISSION_DURATION = 30 * 24 * 60 * 60 * 1000 // 30 days
+
   const getCameraPermissionFromStorage = () => {
     if (typeof window === 'undefined') return null
-    return sessionStorage.getItem('camera_permission_granted') === 'true'
+    try {
+      const stored = localStorage.getItem(CAMERA_PERMISSION_KEY)
+      if (stored) {
+        const { granted, timestamp } = JSON.parse(stored)
+        // Check if stored permission is still valid (30 days)
+        if (granted && Date.now() - timestamp < CAMERA_PERMISSION_DURATION) {
+          return true
+        }
+      }
+    } catch {
+      // Silently fail
+    }
+    return false
   }
 
   const saveCameraPermissionToStorage = (granted: boolean) => {
     if (typeof window === 'undefined') return
-    if (granted) {
-      sessionStorage.setItem('camera_permission_granted', 'true')
-    } else {
-      sessionStorage.removeItem('camera_permission_granted')
+    try {
+      if (granted) {
+        localStorage.setItem(CAMERA_PERMISSION_KEY, JSON.stringify({ 
+          granted: true, 
+          timestamp: Date.now() 
+        }))
+      } else {
+        localStorage.removeItem(CAMERA_PERMISSION_KEY)
+      }
+    } catch {
+      // Silently fail
     }
   }
 

--- a/components/dashboard-map.tsx
+++ b/components/dashboard-map.tsx
@@ -246,7 +246,7 @@ function DashboardMapComponent({ posts, onNewIssue, mapInstance: externalMapInst
 
     const initMap = async () => {
       try {
-        const location = await getCurrentLocationWithName()
+        const location = await getCurrentLocationWithName({ preferCached: true })
         if (location) {
           setUserLocation({
             latitude: location.lat,

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -136,7 +136,7 @@ function MapViewComponent({
     
     const fetchLocation = async () => {
       try {
-        const location = await getCurrentLocationWithName({ useCache: true })
+        const location = await getCurrentLocationWithName({ useCache: true, preferCached: true })
         if (location) {
           setInternalUserLocation({
             latitude: location.latitude,

--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -132,7 +132,7 @@ export function PostCard({ post, showStatusBadge = false }: { post: Post; showSt
   useEffect(() => {
     const getUserLocation = async () => {
       try {
-        const locationData = await getCurrentLocationWithName({ useCache: true })
+        const locationData = await getCurrentLocationWithName({ useCache: true, preferCached: true })
         if (locationData) {
           setUserLocation({
             lat: locationData.latitude,

--- a/tests/unit/geocoding.test.ts
+++ b/tests/unit/geocoding.test.ts
@@ -529,8 +529,8 @@ describe('getCurrentLocationWithName()', () => {
         latitude: 0,
         longitude: 0,
       })
-      // Set permission state to 73 hours ago (expired)
-      const expiredTimestamp = Date.now() - (73 * 60 * 60 * 1000)
+      // Set permission state to 7 months ago (expired - PERMISSION_CACHE_DURATION is ~6 months)
+      const expiredTimestamp = Date.now() - (7 * 30 * 24 * 60 * 60 * 1000)
       localStorage.setItem(LOCATION_PERMISSION_KEY, JSON.stringify({
         status: 'granted',
         lastChecked: expiredTimestamp
@@ -539,9 +539,9 @@ describe('getCurrentLocationWithName()', () => {
       mockGeolocationSuccess(TEST_COORDINATES.sanFrancisco.lat, TEST_COORDINATES.sanFrancisco.lng)
       setMockGeocodingResponse(MOCK_GEOCODING_RESPONSES.sanFrancisco)
 
-      const result = await getCurrentLocationWithName({ useCache: true })
+      const result = await getCurrentLocationWithName({ useCache: true, preferCached: true })
 
-      // getLocationPermissionState() returns 'unknown' for expired state, so cache won't be used
+      // getLocationPermissionState() returns 'unknown' for expired state (> 2 weeks), so preferCached won't apply
       expect(result?.name).toBe('San Francisco, CA')
       expect(fetchCallHistory.length).toBeGreaterThan(0)
     })
@@ -554,7 +554,7 @@ describe('getCurrentLocationWithName()', () => {
           latitude: 0,
           longitude: 0,
         },
-        timestamp: Date.now() - (73 * 60 * 60 * 1000) // 73 hours ago
+        timestamp: Date.now() - (7 * 30 * 24 * 60 * 60 * 1000) // 7 months ago (exceeds 6-month PERMISSION_CACHE_DURATION)
       }
       localStorage.setItem('ganamos_cached_location', JSON.stringify(expiredCache))
       saveLocationPermissionState({ status: 'granted', lastChecked: Date.now() })


### PR DESCRIPTION
## Problem

Users on the PWA mobile app are repeatedly asked for location and camera permissions every time they create a new post.

## Root Causes

1. **No cached location early-return**: `getCurrentLocationWithName()` always called `navigator.geolocation.getCurrentPosition()` even when fresh cached data existed, triggering the browser permission prompt unnecessarily.

2. **No deduplication**: Multiple components (e.g. 5 PostCards + dashboard map) each called `getCurrentPosition` simultaneously on mount, creating multiple concurrent permission prompts.

3. **Camera permission in sessionStorage**: Stored in `sessionStorage` which is cleared every time the PWA is closed/swiped away.

4. **Short cache durations**: Permission cache was only 2 weeks; location freshness was only 1 hour.

## Changes

### Location (`lib/geocoding.ts`)
- Add `preferCached` option — when true, returns cached location without calling the browser API if cache is fresh
- Add in-memory promise deduplication for concurrent `getCurrentPosition` calls
- Extend permission cache from 2 weeks → **6 months**
- Extend location freshness from 1 hour → **4 hours**

### Callers
- **Non-critical flows** (PostCard, dashboard map, map page, donate page, map-view): Use `preferCached: true` — avoids prompts entirely
- **Post flow** (`handleCapture`): Gets real-time GPS coordinates every time (no `preferCached`) — precision matters here, and the browser won't re-prompt since permission was already granted from earlier flows

### Camera (`components/camera-capture.tsx`)
- Switch from `sessionStorage` to `localStorage` with 30-day timestamp-based expiry

### Tests
- Updated cache expiry test timestamps to match new 6-month duration
- Updated test to use `preferCached` where appropriate