### PR TITLE
feat: add pickleball wagering system

### DIFF
--- a/app/api/game/pickleball/complete/route.ts
+++ b/app/api/game/pickleball/complete/route.ts
@@ -1,16 +1,16 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase"
 import { checkRateLimit } from "@/lib/rate-limiter"
+import { v4 as uuidv4 } from "uuid"
 
 export const dynamic = "force-dynamic"
 
 /**
  * POST /api/game/pickleball/complete
- * Called by host device when game finishes to record results.
- * Awards happiness bonus to winning side.
+ * Called by host device when game finishes to record results and settle wagers.
  * 
  * Body: { gameId, deviceId, scoreLeft, scoreRight, winnerSide }
- * Returns: { success }
+ * Returns: { success, wagerSettled?, payouts[]? }
  */
 export async function POST(request: NextRequest) {
   try {
@@ -31,7 +31,6 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Rate limit
     const rateLimit = checkRateLimit(`pickleball-complete-${deviceId}`, {
       maxRequests: 5,
       windowMs: 60 * 1000,
@@ -45,7 +44,6 @@ export async function POST(request: NextRequest) {
 
     const supabase = createServerSupabaseClient()
 
-    // Verify game exists and this device is the host
     const { data: game, error: gameError } = await supabase
       .from("pickleball_games")
       .select("*")
@@ -67,26 +65,150 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // Update game with final results
-    const { error: updateError } = await supabase
-      .from("pickleball_games")
-      .update({
-        status: "completed",
-        score_left: scoreLeft || 0,
-        score_right: scoreRight || 0,
-        winner_side: winnerSide,
-        completed_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", gameId)
-
-    if (updateError) {
-      console.error("[Pickleball] Failed to complete game:", updateError)
-      return NextResponse.json(
-        { success: false, error: "Failed to save game results" },
-        { status: 500 }
-      )
+    // Record final results
+    const gameUpdate: Record<string, any> = {
+      status: "completed",
+      score_left: scoreLeft || 0,
+      score_right: scoreRight || 0,
+      winner_side: winnerSide,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
     }
+
+    const players = (game.players as any[]) || []
+    const wagerAmount = game.wager_amount || 0
+    const wagerStatus = game.wager_status || "none"
+    let wagerSettled = false
+    const payouts: Array<{ userId: string; petName: string; amount: number }> = []
+
+    // Settle wager if active
+    if (wagerAmount > 0 && wagerStatus === "active") {
+      const loserSide = winnerSide === "left" ? "right" : "left"
+      const winners = players.filter((p: any) => p.side === winnerSide && p.wagerAccepted !== false)
+      const losers = players.filter((p: any) => p.side === loserSide && p.wagerAccepted !== false)
+
+      if (winners.length > 0 && losers.length > 0) {
+        const payoutPerWinner = Math.floor((wagerAmount * losers.length) / winners.length)
+
+        // Distribute: pair each loser with winners proportionally
+        // Each loser pays wagerAmount total, split across winners
+        const amountPerLoserPerWinner = Math.floor(wagerAmount / winners.length)
+
+        let allTransfersOk = true
+
+        for (const loser of losers) {
+          for (const winner of winners) {
+            if (loser.userId === winner.userId) continue
+
+            const transferAmount = amountPerLoserPerWinner
+            if (transferAmount <= 0) continue
+
+            const senderTxId = uuidv4()
+            const receiverTxId = uuidv4()
+            const now = new Date().toISOString()
+
+            // Create pending transactions
+            await supabase.from("transactions").insert({
+              id: senderTxId,
+              user_id: loser.userId,
+              type: "internal",
+              amount: -transferAmount,
+              status: "pending",
+              memo: `Pickleball wager lost`,
+            })
+
+            await supabase.from("transactions").insert({
+              id: receiverTxId,
+              user_id: winner.userId,
+              type: "internal",
+              amount: transferAmount,
+              status: "pending",
+              memo: `Pickleball wager won`,
+            })
+
+            // Execute atomic transfer
+            const { data: transferResult, error: transferError } = await supabase.rpc(
+              "atomic_transfer",
+              {
+                p_sender_id: loser.userId,
+                p_receiver_id: winner.userId,
+                p_amount: transferAmount,
+                p_sender_tx_id: senderTxId,
+                p_receiver_tx_id: receiverTxId,
+              }
+            )
+
+            if (transferError || !transferResult?.success) {
+              console.error(`[Pickleball] Transfer failed: ${loser.userId} → ${winner.userId}:`, transferError || transferResult)
+              allTransfersOk = false
+              // Mark failed transactions
+              await supabase
+                .from("transactions")
+                .update({ status: "failed", updated_at: now })
+                .in("id", [senderTxId, receiverTxId])
+            }
+          }
+        }
+
+        if (allTransfersOk) {
+          // Create activity records
+          const activities = []
+          const now = new Date().toISOString()
+
+          for (const winner of winners) {
+            activities.push({
+              id: uuidv4(),
+              user_id: winner.userId,
+              type: "pickleball_wager",
+              related_id: gameId,
+              related_table: "pickleball_games",
+              timestamp: now,
+              metadata: {
+                amount: payoutPerWinner,
+                result: "won",
+                wagerAmount,
+                scoreLeft: scoreLeft || 0,
+                scoreRight: scoreRight || 0,
+              },
+            })
+            payouts.push({ userId: winner.userId, petName: winner.petName, amount: payoutPerWinner })
+          }
+
+          for (const loser of losers) {
+            activities.push({
+              id: uuidv4(),
+              user_id: loser.userId,
+              type: "pickleball_wager",
+              related_id: gameId,
+              related_table: "pickleball_games",
+              timestamp: now,
+              metadata: {
+                amount: -wagerAmount,
+                result: "lost",
+                wagerAmount,
+                scoreLeft: scoreLeft || 0,
+                scoreRight: scoreRight || 0,
+              },
+            })
+            payouts.push({ userId: loser.userId, petName: loser.petName, amount: -wagerAmount })
+          }
+
+          await supabase.from("activities").insert(activities)
+
+          gameUpdate.wager_status = "settled"
+          wagerSettled = true
+
+          console.log(`[Pickleball] Wager settled for game ${gameId}. ${winners.length} winners got ${payoutPerWinner} sats each.`)
+        } else {
+          console.error(`[Pickleball] Wager settlement had failures for game ${gameId}`)
+        }
+      }
+    }
+
+    await supabase
+      .from("pickleball_games")
+      .update(gameUpdate)
+      .eq("id", gameId)
 
     console.log(`[Pickleball] Game ${gameId} completed. Score: L${scoreLeft}-R${scoreRight}. Winner: ${winnerSide}`)
 
@@ -95,6 +217,8 @@ export async function POST(request: NextRequest) {
       scoreLeft,
       scoreRight,
       winnerSide,
+      wagerSettled,
+      payouts: payouts.length > 0 ? payouts : undefined,
     })
   } catch (error) {
     console.error("[Pickleball] Complete error:", error)

--- a/app/api/game/pickleball/create/route.ts
+++ b/app/api/game/pickleball/create/route.ts
@@ -15,7 +15,15 @@ export const dynamic = "force-dynamic"
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { deviceId, macAddress } = body
+    const { deviceId, macAddress, wagerAmount: rawWager } = body
+    const wagerAmount = Number(rawWager) || 0
+
+    if (wagerAmount !== 0 && wagerAmount !== 100 && wagerAmount !== 500 && wagerAmount !== 1000) {
+      return NextResponse.json(
+        { success: false, error: "Wager must be 0, 100, 500, or 1000" },
+        { status: 400 }
+      )
+    }
 
     if (!deviceId) {
       return NextResponse.json(
@@ -65,6 +73,22 @@ export async function POST(request: NextRequest) {
       .from("devices")
       .update({ mac_address: macAddress })
       .eq("id", deviceId)
+
+    // 2b. If wager > 0, verify host has sufficient balance
+    if (wagerAmount > 0) {
+      const { data: hostProfile } = await supabase
+        .from("profiles")
+        .select("balance")
+        .eq("id", device.user_id)
+        .single()
+
+      if (!hostProfile || hostProfile.balance < wagerAmount) {
+        return NextResponse.json(
+          { success: false, error: "Insufficient balance for wager" },
+          { status: 400 }
+        )
+      }
+    }
 
     // 3. Check for existing active game from this device
     const { data: existingGame } = await supabase
@@ -165,6 +189,18 @@ export async function POST(request: NextRequest) {
               ]
               const assignment = sideAssignments[players.length]
 
+              // Check joiner's balance against the game's wager
+              const gameWager = existingGame.wager_amount || 0
+              let joinerWagerAccepted = true
+              if (gameWager > 0) {
+                const { data: joinerProfile } = await supabase
+                  .from("profiles")
+                  .select("balance")
+                  .eq("id", device.user_id)
+                  .single()
+                joinerWagerAccepted = !!(joinerProfile && joinerProfile.balance >= gameWager)
+              }
+
               const joiningPlayer = {
                 userId: device.user_id,
                 deviceId: device.id,
@@ -174,16 +210,28 @@ export async function POST(request: NextRequest) {
                 side: assignment.side,
                 position: assignment.position,
                 joinedAt: new Date().toISOString(),
+                wagerAccepted: joinerWagerAccepted,
               }
 
               const updatedPlayers = [...players, joiningPlayer]
 
+              const gameUpdate: Record<string, any> = {
+                players: updatedPlayers,
+                updated_at: new Date().toISOString(),
+              }
+              if (!joinerWagerAccepted && existingGame.wager_status === "active") {
+                gameUpdate.wager_status = "declined"
+              }
+
               await supabase
                 .from("pickleball_games")
-                .update({ players: updatedPlayers, updated_at: new Date().toISOString() })
+                .update(gameUpdate)
                 .eq("id", existingGame.id)
 
               const hostPlayer = players[0]
+              const updatedWagerStatus = joinerWagerAccepted
+                ? (existingGame.wager_status || "none")
+                : "declined"
 
               console.log(`[Pickleball] Device ${deviceId} auto-joined existing game ${existingGame.id} as player ${players.length}`)
 
@@ -198,6 +246,9 @@ export async function POST(request: NextRequest) {
                 yourPosition: assignment.position,
                 players: updatedPlayers,
                 playerCount: updatedPlayers.length,
+                wagerAmount: gameWager,
+                wagerAccepted: joinerWagerAccepted,
+                wagerStatus: updatedWagerStatus,
               })
             }
           }
@@ -215,6 +266,7 @@ export async function POST(request: NextRequest) {
       side: "left",
       position: "top",
       joinedAt: new Date().toISOString(),
+      wagerAccepted: wagerAmount > 0 ? true : undefined,
     }
 
     const lobbyExpiresAt = new Date(Date.now() + 60 * 1000).toISOString()
@@ -227,6 +279,8 @@ export async function POST(request: NextRequest) {
         status: "lobby",
         players: [hostPlayer],
         lobby_expires_at: lobbyExpiresAt,
+        wager_amount: wagerAmount,
+        wager_status: wagerAmount > 0 ? "active" : "none",
       })
       .select("id")
       .single()
@@ -247,6 +301,8 @@ export async function POST(request: NextRequest) {
       gameId: game.id,
       lobbyExpiresAt,
       potentialPlayers: potentialPlayers.length,
+      wagerAmount,
+      wagerStatus: wagerAmount > 0 ? "active" : "none",
     })
   } catch (error) {
     console.error("[Pickleball] Create error:", error)

--- a/app/api/game/pickleball/join/route.ts
+++ b/app/api/game/pickleball/join/route.ts
@@ -127,6 +127,18 @@ export async function POST(request: NextRequest) {
     ]
     const assignment = assignments[players.length]
 
+    // 5b. Check joiner's balance against game wager
+    const gameWager = game.wager_amount || 0
+    let wagerAccepted = true
+    if (gameWager > 0) {
+      const { data: joinerProfile } = await supabase
+        .from("profiles")
+        .select("balance")
+        .eq("id", device.user_id)
+        .single()
+      wagerAccepted = !!(joinerProfile && joinerProfile.balance >= gameWager)
+    }
+
     const newPlayer = {
       userId: device.user_id,
       deviceId: device.id,
@@ -136,17 +148,23 @@ export async function POST(request: NextRequest) {
       side: assignment.side,
       position: assignment.position,
       joinedAt: new Date().toISOString(),
+      wagerAccepted: gameWager > 0 ? wagerAccepted : undefined,
     }
 
     const updatedPlayers = [...players, newPlayer]
 
-    // 6. Update game with new player
+    // 6. Update game with new player (and wager_status if declined)
+    const gameUpdate: Record<string, any> = {
+      players: updatedPlayers,
+      updated_at: new Date().toISOString(),
+    }
+    if (!wagerAccepted && game.wager_status === "active") {
+      gameUpdate.wager_status = "declined"
+    }
+
     const { error: updateError } = await supabase
       .from("pickleball_games")
-      .update({
-        players: updatedPlayers,
-        updated_at: new Date().toISOString(),
-      })
+      .update(gameUpdate)
       .eq("id", gameId)
 
     if (updateError) {
@@ -157,7 +175,11 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    console.log(`[Pickleball] Device ${deviceId} (${device.pet_name}) joined game ${gameId}. Players: ${updatedPlayers.length}`)
+    const updatedWagerStatus = !wagerAccepted && game.wager_status === "active"
+      ? "declined"
+      : (game.wager_status || "none")
+
+    console.log(`[Pickleball] Device ${deviceId} (${device.pet_name}) joined game ${gameId}. Players: ${updatedPlayers.length}. Wager accepted: ${wagerAccepted}`)
 
     return NextResponse.json({
       success: true,
@@ -165,6 +187,9 @@ export async function POST(request: NextRequest) {
       playerCount: updatedPlayers.length,
       yourSide: assignment.side,
       yourPosition: assignment.position,
+      wagerAmount: gameWager,
+      wagerAccepted,
+      wagerStatus: updatedWagerStatus,
     })
   } catch (error) {
     console.error("[Pickleball] Join error:", error)

--- a/app/api/game/pickleball/state/route.ts
+++ b/app/api/game/pickleball/state/route.ts
@@ -101,6 +101,8 @@ export async function GET(request: NextRequest) {
       lobbyExpiresAt: game.lobby_expires_at,
       scoreLeft: game.score_left,
       scoreRight: game.score_right,
+      wagerAmount: game.wager_amount || 0,
+      wagerStatus: game.wager_status || "none",
     })
   } catch (error) {
     console.error("[Pickleball] State error:", error)

--- a/supabase/migrations/20260226000001_pickleball_wager.sql
+++ b/supabase/migrations/20260226000001_pickleball_wager.sql
@@ -1,0 +1,9 @@
+-- Add wagering support to pickleball games
+ALTER TABLE pickleball_games
+  ADD COLUMN IF NOT EXISTS wager_amount INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS wager_status VARCHAR NOT NULL DEFAULT 'none';
+
+-- Constrain wager_status values
+ALTER TABLE pickleball_games
+  ADD CONSTRAINT pickleball_wager_status_check
+  CHECK (wager_status IN ('none', 'active', 'declined', 'settled'));


### PR DESCRIPTION
## Summary

- **DB migration**: Adds `wager_amount` (integer, default 0) and `wager_status` (varchar, constrained to none/active/declined/settled) columns to `pickleball_games`
- **Create endpoint**: Accepts `wagerAmount` from host, validates balance, stores on game row. Auto-join path checks joiner balance and sets `wagerAccepted` per player; declines update `wager_status`
- **Join endpoint**: Checks joiner balance against game wager, sets `wagerAccepted`, updates `wager_status` to declined if insufficient funds
- **State endpoint**: Returns `wagerAmount` and `wagerStatus` so devices can display wager info in lobby
- **Complete endpoint**: On game completion with an active wager, identifies winners/losers, executes `atomic_transfer` for each loser→winner pair, creates transaction records (debit/credit), creates activity records (`pickleball_wager` type), and returns per-player payouts

## Payout Math

Each player wagers X sats. Losers lose X. Winners split total losings evenly.
- **1v1 at 100**: loser pays 100 to winner
- **2v2 at 100**: each loser pays 100, each winner receives 100 (net +100)  
- **1v2 at 100**: if solo wins, gets 200; if team wins, each gets 50

## Test plan

- [ ] Run migration on Supabase SQL editor
- [ ] Create a game with wager=100, verify `wager_amount` and `wager_status=active` in DB
- [ ] Join with a player who has insufficient balance, verify `wager_status` flips to `declined`
- [ ] Complete a wager game, verify atomic transfers execute and balances update
- [ ] Verify activity records are created for all participants
- [ ] Test free game (wager=0) to ensure no regression

Made with [Cursor](https://cursor.com)