### PR TITLE
feat: open pickleball lobbies + fix invite notifications + wager join flow

### DIFF
--- a/app/api/device/config/route.ts
+++ b/app/api/device/config/route.ts
@@ -306,20 +306,25 @@ export async function GET(request: NextRequest) {
       console.warn("[Device Config] Error calculating coins earned:", error)
     }
 
+    // Get user's group memberships (shared across jobs + pickleball invite checks)
+    let groupIds: string[] = []
+    try {
+      const { data: memberships } = await supabase
+        .from("group_members")
+        .select("group_id")
+        .eq("user_id", device.user_id)
+        .eq("status", "approved")
+      groupIds = memberships?.map(m => m.group_id) || []
+    } catch (error) {
+      console.warn("[Device Config] Error fetching group memberships:", error)
+    }
+
     // Check for new jobs in user's groups OR assigned directly to user (for notification)
     let hasNewJob = false
     let newJobTitle: string | null = null
     let newJobReward: number | null = null
     
     try {
-      // Get user's group memberships
-      const { data: memberships } = await supabase
-        .from("group_members")
-        .select("group_id")
-        .eq("user_id", device.user_id)
-        .eq("status", "approved")
-      
-      const groupIds = memberships?.map(m => m.group_id) || []
       let newestJob: { id: string; title: string; reward: number; created_at: string } | null = null
       
       // Check for newest group job (if user has any groups)
@@ -384,50 +389,30 @@ export async function GET(request: NextRequest) {
       console.warn("[Device Config] Error checking for new jobs:", error)
     }
 
-    // Check for active pickleball game invites
-    // Look for games in 'lobby' or 'countdown' status where this user is in the same group
+    // Check for active pickleball game invites (any active lobby, not just group members)
     let pickleballInvite: { gameId: string; hostPetName: string; playerCount: number; hostMac: string } | null = null
     
     try {
-      if (groupIds && groupIds.length > 0) {
-        // Find active games from group members (not from this device)
-        const { data: activeGames } = await supabase
-          .from("pickleball_games")
-          .select("id, host_device_id, host_user_id, players, lobby_expires_at")
-          .in("status", ["lobby", "countdown"])
-          .neq("host_device_id", device.id)
-          .gt("lobby_expires_at", new Date().toISOString())
-          .order("created_at", { ascending: false })
-          .limit(5)
-        
-        if (activeGames && activeGames.length > 0) {
-          // Check if any game host is in the same group
-          for (const game of activeGames) {
-            // Verify host is in one of user's groups
-            const { data: hostMembership } = await supabase
-              .from("group_members")
-              .select("id")
-              .in("group_id", groupIds)
-              .eq("user_id", game.host_user_id)
-              .eq("status", "approved")
-              .limit(1)
-              .single()
-            
-            if (hostMembership) {
-              const players = (game.players as any[]) || []
-              // Don't invite if already in the game or game is full
-              const alreadyJoined = players.some((p: any) => p.deviceId === device.id)
-              if (!alreadyJoined && players.length < 4) {
-                const hostPlayer = players[0]
-                pickleballInvite = {
-                  gameId: game.id,
-                  hostPetName: hostPlayer?.petName || "Someone",
-                  playerCount: players.length,
-                  hostMac: hostPlayer?.macAddress || "",
-                }
-                break // Take first valid invite
-              }
-            }
+      const { data: activeGames } = await supabase
+        .from("pickleball_games")
+        .select("id, host_device_id, host_user_id, players, lobby_expires_at")
+        .in("status", ["lobby", "countdown"])
+        .neq("host_device_id", device.id)
+        .gt("lobby_expires_at", new Date().toISOString())
+        .order("created_at", { ascending: false })
+        .limit(1)
+      
+      if (activeGames && activeGames.length > 0) {
+        const game = activeGames[0]
+        const players = (game.players as any[]) || []
+        const alreadyJoined = players.some((p: any) => p.deviceId === device.id)
+        if (!alreadyJoined && players.length < 4) {
+          const hostPlayer = players[0]
+          pickleballInvite = {
+            gameId: game.id,
+            hostPetName: hostPlayer?.petName || "Someone",
+            playerCount: players.length,
+            hostMac: hostPlayer?.macAddress || "",
           }
         }
       }

--- a/app/api/game/pickleball/create/route.ts
+++ b/app/api/game/pickleball/create/route.ts
@@ -6,11 +6,11 @@ export const dynamic = "force-dynamic"
 
 /**
  * POST /api/game/pickleball/create
- * Called by host device to create a new pickleball game lobby.
- * Finds all group members with paired devices and creates a game session.
+ * Called by a device to create or join a pickleball game lobby.
+ * Auto-joins an existing lobby if one is available, otherwise creates a new one.
  * 
- * Body: { deviceId, macAddress }
- * Returns: { success, gameId, groupMembers[] }
+ * Body: { deviceId, macAddress, wagerAmount? }
+ * Returns: { success, gameId, action: "host"|"join", ... }
  */
 export async function POST(request: NextRequest) {
   try {
@@ -106,152 +106,82 @@ export async function POST(request: NextRequest) {
         .eq("id", existingGame.id)
     }
 
-    // 4. Find all group members who have paired devices
-    //    Get user's groups first
-    const { data: memberships } = await supabase
-      .from("group_members")
-      .select("group_id")
-      .eq("user_id", device.user_id)
-      .eq("status", "approved")
+    // 4. Before creating a new game, check if any active lobby exists to join
+    const { data: existingLobbies } = await supabase
+      .from("pickleball_games")
+      .select("*")
+      .in("status", ["lobby"])
+      .neq("host_device_id", deviceId)
+      .gt("lobby_expires_at", new Date().toISOString())
+      .order("created_at", { ascending: false })
+      .limit(5)
 
-    const groupIds = memberships?.map(m => m.group_id) || []
+    if (existingLobbies && existingLobbies.length > 0) {
+      for (const existingGame of existingLobbies) {
+        const players = (existingGame.players as any[]) || []
+        const alreadyJoined = players.some((p: any) => p.deviceId === deviceId)
 
-    // Find other users in these groups who also have paired devices
-    let potentialPlayers: Array<{
-      userId: string
-      deviceId: string
-      petName: string
-      petInitial: string
-    }> = []
+        if (!alreadyJoined && players.length < 4) {
+          const sideAssignments = [
+            { side: "left", position: "top" },
+            { side: "right", position: "top" },
+            { side: "right", position: "bottom" },
+            { side: "left", position: "bottom" },
+          ]
+          const assignment = sideAssignments[players.length]
 
-    if (groupIds.length > 0) {
-      // Get all approved members in user's groups (excluding self)
-      const { data: groupMembers } = await supabase
-        .from("group_members")
-        .select("user_id")
-        .in("group_id", groupIds)
-        .eq("status", "approved")
-        .neq("user_id", device.user_id)
-
-      const memberUserIds = [...new Set(groupMembers?.map(m => m.user_id) || [])]
-
-      if (memberUserIds.length > 0) {
-        // Find paired devices for these users
-        const { data: memberDevices } = await supabase
-          .from("devices")
-          .select("id, user_id, pet_name")
-          .in("user_id", memberUserIds)
-          .eq("status", "paired")
-
-        if (memberDevices) {
-          potentialPlayers = memberDevices.map(d => ({
-            userId: d.user_id,
-            deviceId: d.id,
-            petName: d.pet_name,
-            petInitial: d.pet_name.charAt(0).toUpperCase(),
-          }))
-        }
-      }
-    }
-
-    // 5. Before creating a new game, check if a group member already has an active lobby
-    if (groupIds.length > 0) {
-      const { data: existingGroupGames } = await supabase
-        .from("pickleball_games")
-        .select("*")
-        .in("status", ["lobby"])
-        .neq("host_device_id", deviceId)
-        .gt("lobby_expires_at", new Date().toISOString())
-        .order("created_at", { ascending: false })
-        .limit(5)
-
-      if (existingGroupGames && existingGroupGames.length > 0) {
-        for (const existingGame of existingGroupGames) {
-          const { data: hostInGroup } = await supabase
-            .from("group_members")
-            .select("id")
-            .in("group_id", groupIds)
-            .eq("user_id", existingGame.host_user_id)
-            .eq("status", "approved")
-            .limit(1)
-            .single()
-
-          if (hostInGroup) {
-            const players = (existingGame.players as any[]) || []
-            const alreadyJoined = players.some((p: any) => p.deviceId === deviceId)
-
-            if (!alreadyJoined && players.length < 4) {
-              const sideAssignments = [
-                { side: "left", position: "top" },
-                { side: "right", position: "top" },
-                { side: "right", position: "bottom" },
-                { side: "left", position: "bottom" },
-              ]
-              const assignment = sideAssignments[players.length]
-
-              // Check joiner's balance against the game's wager
-              const gameWager = existingGame.wager_amount || 0
-              let joinerWagerAccepted = true
-              if (gameWager > 0) {
-                const { data: joinerProfile } = await supabase
-                  .from("profiles")
-                  .select("balance")
-                  .eq("id", device.user_id)
-                  .single()
-                joinerWagerAccepted = !!(joinerProfile && joinerProfile.balance >= gameWager)
-              }
-
-              const joiningPlayer = {
-                userId: device.user_id,
-                deviceId: device.id,
-                petName: device.pet_name,
-                petInitial: device.pet_name.charAt(0).toUpperCase(),
-                macAddress,
-                side: assignment.side,
-                position: assignment.position,
-                joinedAt: new Date().toISOString(),
-                wagerAccepted: joinerWagerAccepted,
-              }
-
-              const updatedPlayers = [...players, joiningPlayer]
-
-              const gameUpdate: Record<string, any> = {
-                players: updatedPlayers,
-                updated_at: new Date().toISOString(),
-              }
-              if (!joinerWagerAccepted && existingGame.wager_status === "active") {
-                gameUpdate.wager_status = "declined"
-              }
-
-              await supabase
-                .from("pickleball_games")
-                .update(gameUpdate)
-                .eq("id", existingGame.id)
-
-              const hostPlayer = players[0]
-              const updatedWagerStatus = joinerWagerAccepted
-                ? (existingGame.wager_status || "none")
-                : "declined"
-
-              console.log(`[Pickleball] Device ${deviceId} auto-joined existing game ${existingGame.id} as player ${players.length}`)
-
-              return NextResponse.json({
-                success: true,
-                action: "join",
-                gameId: existingGame.id,
-                hostMac: hostPlayer?.macAddress || "",
-                hostPetName: hostPlayer?.petName || "Someone",
-                playerIndex: players.length,
-                yourSide: assignment.side,
-                yourPosition: assignment.position,
-                players: updatedPlayers,
-                playerCount: updatedPlayers.length,
-                wagerAmount: gameWager,
-                wagerAccepted: joinerWagerAccepted,
-                wagerStatus: updatedWagerStatus,
-              })
+          // Check joiner's balance against the game's wager
+          const gameWager = existingGame.wager_amount || 0
+          if (gameWager > 0) {
+            const { data: joinerProfile } = await supabase
+              .from("profiles")
+              .select("balance")
+              .eq("id", device.user_id)
+              .single()
+            if (!joinerProfile || joinerProfile.balance < gameWager) {
+              // Insufficient balance for this wager game — skip it, try next lobby
+              continue
             }
           }
+
+          const joiningPlayer = {
+            userId: device.user_id,
+            deviceId: device.id,
+            petName: device.pet_name,
+            petInitial: device.pet_name.charAt(0).toUpperCase(),
+            macAddress,
+            side: assignment.side,
+            position: assignment.position,
+            joinedAt: new Date().toISOString(),
+            wagerAccepted: gameWager > 0 ? true : undefined,
+          }
+
+          const updatedPlayers = [...players, joiningPlayer]
+
+          await supabase
+            .from("pickleball_games")
+            .update({ players: updatedPlayers, updated_at: new Date().toISOString() })
+            .eq("id", existingGame.id)
+
+          const hostPlayer = players[0]
+
+          console.log(`[Pickleball] Device ${deviceId} auto-joined existing game ${existingGame.id} as player ${players.length}`)
+
+          return NextResponse.json({
+            success: true,
+            action: "join",
+            gameId: existingGame.id,
+            hostMac: hostPlayer?.macAddress || "",
+            hostPetName: hostPlayer?.petName || "Someone",
+            playerIndex: players.length,
+            yourSide: assignment.side,
+            yourPosition: assignment.position,
+            players: updatedPlayers,
+            playerCount: updatedPlayers.length,
+            wagerAmount: gameWager,
+            wagerAccepted: true,
+            wagerStatus: existingGame.wager_status || "none",
+          })
         }
       }
     }
@@ -293,14 +223,13 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    console.log(`[Pickleball] Game ${game.id} created by device ${deviceId}. ${potentialPlayers.length} potential players in group.`)
+    console.log(`[Pickleball] Game ${game.id} created by device ${deviceId}.`)
 
     return NextResponse.json({
       success: true,
       action: "host",
       gameId: game.id,
       lobbyExpiresAt,
-      potentialPlayers: potentialPlayers.length,
       wagerAmount,
       wagerStatus: wagerAmount > 0 ? "active" : "none",
     })

--- a/app/api/game/pickleball/join/route.ts
+++ b/app/api/game/pickleball/join/route.ts
@@ -127,16 +127,20 @@ export async function POST(request: NextRequest) {
     ]
     const assignment = assignments[players.length]
 
-    // 5b. Check joiner's balance against game wager
+    // 5b. Check joiner's balance against game wager — reject if insufficient
     const gameWager = game.wager_amount || 0
-    let wagerAccepted = true
     if (gameWager > 0) {
       const { data: joinerProfile } = await supabase
         .from("profiles")
         .select("balance")
         .eq("id", device.user_id)
         .single()
-      wagerAccepted = !!(joinerProfile && joinerProfile.balance >= gameWager)
+      if (!joinerProfile || joinerProfile.balance < gameWager) {
+        return NextResponse.json(
+          { success: false, error: "Insufficient balance for wager", wagerAmount: gameWager },
+          { status: 400 }
+        )
+      }
     }
 
     const newPlayer = {
@@ -148,23 +152,18 @@ export async function POST(request: NextRequest) {
       side: assignment.side,
       position: assignment.position,
       joinedAt: new Date().toISOString(),
-      wagerAccepted: gameWager > 0 ? wagerAccepted : undefined,
+      wagerAccepted: gameWager > 0 ? true : undefined,
     }
 
     const updatedPlayers = [...players, newPlayer]
 
-    // 6. Update game with new player (and wager_status if declined)
-    const gameUpdate: Record<string, any> = {
-      players: updatedPlayers,
-      updated_at: new Date().toISOString(),
-    }
-    if (!wagerAccepted && game.wager_status === "active") {
-      gameUpdate.wager_status = "declined"
-    }
-
+    // 6. Update game with new player
     const { error: updateError } = await supabase
       .from("pickleball_games")
-      .update(gameUpdate)
+      .update({
+        players: updatedPlayers,
+        updated_at: new Date().toISOString(),
+      })
       .eq("id", gameId)
 
     if (updateError) {
@@ -175,11 +174,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const updatedWagerStatus = !wagerAccepted && game.wager_status === "active"
-      ? "declined"
-      : (game.wager_status || "none")
-
-    console.log(`[Pickleball] Device ${deviceId} (${device.pet_name}) joined game ${gameId}. Players: ${updatedPlayers.length}. Wager accepted: ${wagerAccepted}`)
+    console.log(`[Pickleball] Device ${deviceId} (${device.pet_name}) joined game ${gameId}. Players: ${updatedPlayers.length}`)
 
     return NextResponse.json({
       success: true,
@@ -188,8 +183,8 @@ export async function POST(request: NextRequest) {
       yourSide: assignment.side,
       yourPosition: assignment.position,
       wagerAmount: gameWager,
-      wagerAccepted,
-      wagerStatus: updatedWagerStatus,
+      wagerAccepted: true,
+      wagerStatus: game.wager_status || "none",
     })
   } catch (error) {
     console.error("[Pickleball] Join error:", error)


### PR DESCRIPTION
## Summary

- **Remove group membership restriction**: Any device can now discover and join any active Pickleball lobby. ESP-NOW proximity is the natural gameplay filter — if you're not physically nearby, the game can't play out anyway.
- **Fix invite notifications**: The `groupIds` variable was defined inside a try block (job checking) and was inaccessible to the pickleball invite check, causing notifications to silently fail on every config poll. Simplified the invite check to find any active lobby.
- **Reject insufficient balance**: If a wager game exists and a joiner doesn't have enough sats, the server now rejects the join outright (HTTP 400) instead of joining with `wagerAccepted=false`.

## Test plan

- [ ] Device A creates a Pickleball game → lobby created
- [ ] Device B (not in same group) selects Pickleball → auto-joins Device A's lobby
- [ ] Both devices see each other in lobby, either can start the game
- [ ] Config polling returns `pickleballInvite` for devices that haven't joined yet
- [ ] Wager game: joiner with insufficient balance gets rejected
- [ ] Free game: no wager screen shown to joiners

Made with [Cursor](https://cursor.com)