### PR TITLE
feat: add set_wager action + pickleball flow improvements

### DIFF
--- a/app/api/game/pickleball/state/route.ts
+++ b/app/api/game/pickleball/state/route.ts
@@ -182,6 +182,50 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true, status: "playing" })
     }
 
+    if (action === "set_wager") {
+      const wagerAmount = Number(body.wagerAmount) || 0
+      if (wagerAmount !== 0 && wagerAmount !== 100 && wagerAmount !== 500 && wagerAmount !== 1000) {
+        return NextResponse.json(
+          { success: false, error: "Wager must be 0, 100, 500, or 1000" },
+          { status: 400 }
+        )
+      }
+
+      // Verify host has sufficient balance
+      if (wagerAmount > 0) {
+        const { data: hostProfile } = await supabase
+          .from("profiles")
+          .select("balance")
+          .eq("id", game.host_user_id)
+          .single()
+
+        if (!hostProfile || hostProfile.balance < wagerAmount) {
+          return NextResponse.json(
+            { success: false, error: "Insufficient balance for wager" },
+            { status: 400 }
+          )
+        }
+      }
+
+      // Update host player's wagerAccepted in the players array
+      const updatedPlayers = players.map((p: any, i: number) =>
+        i === 0 ? { ...p, wagerAccepted: wagerAmount > 0 ? true : undefined } : p
+      )
+
+      await supabase
+        .from("pickleball_games")
+        .update({
+          wager_amount: wagerAmount,
+          wager_status: wagerAmount > 0 ? "active" : "none",
+          players: updatedPlayers,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", gameId)
+
+      console.log(`[Pickleball] Game ${gameId} wager set to ${wagerAmount} by host`)
+      return NextResponse.json({ success: true, wagerAmount, wagerStatus: wagerAmount > 0 ? "active" : "none" })
+    }
+
     if (action === "cancel") {
       await supabase
         .from("pickleball_games")


### PR DESCRIPTION
## Summary

- **New `set_wager` action** on the state endpoint: allows the host to update the wager amount after creating a game. Validates the wager value (0/100/500/1000), checks host balance, and updates the game row. This supports the reordered firmware flow where devices first try to find/join an existing lobby, and only show the wager selection if they end up hosting.

## Firmware changes (local, not in this PR)

- **Reordered flow**: Play > Pickleball now immediately searches for an existing game. If one is found, the player joins and sees a wager acceptance screen (if applicable). Only if no game exists does the wager selection screen appear.
- **Suppressed duplicate notification**: After a wager game, the next config-poll balance increase celebration is suppressed since the game-over screen already showed the result with sound.

## Test plan

- [ ] Host creates game → no existing lobby → sees wager selection → game created with wager
- [ ] Second player selects Pickleball → finds existing game → joins → sees wager acceptance (if wager > 0) → enters lobby
- [ ] Free game: no wager screens shown to joiners
- [ ] Wager win: only one celebration shown (game-over screen), not a second one from config poll

Made with [Cursor](https://cursor.com)