### PR TITLE
fix: use EARTH_PLACEHOLDER_IMAGE constant and add has_image handling to map views

### DIFF
--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -19,6 +19,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import type { Post } from "@/lib/types"
+import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { reverseGeocode } from "@/lib/geocoding"
 import { uploadImage, generateImagePath, isBase64Image } from "@/lib/storage"
 // Add the new server actions to imports
@@ -1750,10 +1751,10 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
               <div>
                 <div 
                   className="relative w-full h-40 overflow-hidden rounded-lg cursor-pointer transition-opacity hover:opacity-90"
-                  onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? '/images/earth-placeholder.jpg' : '/placeholder.svg'))}
+                  onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg'))}
                 >
                   <Image
-                    src={post.imageUrl || post.image_url || (post.has_image === false ? '/images/earth-placeholder.jpg' : '/placeholder.svg')}
+                    src={post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
                     alt="Before"
                     fill
                     className="object-cover"
@@ -1837,10 +1838,10 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
           ) : (
             <div 
               className="relative w-full h-64 mb-4 overflow-hidden rounded-lg cursor-pointer transition-opacity hover:opacity-95"
-              onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? '/images/earth-placeholder.jpg' : '/placeholder.svg'))}
+              onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg'))}
             >
               <Image
-                src={post.imageUrl || post.image_url || (post.has_image === false ? '/images/earth-placeholder.jpg' : '/placeholder.svg')}
+                src={post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
                 alt={post.title}
                 fill
                 className="object-cover"

--- a/components/map-modal.tsx
+++ b/components/map-modal.tsx
@@ -8,6 +8,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { Loader2, X, RefreshCw, MapPin, AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Post } from "@/lib/types"
+import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatSatsValue, formatTimeAgo } from "@/lib/utils"
 import { loadGoogleMaps } from "@/lib/google-maps-loader"
 
@@ -480,7 +481,7 @@ export function MapModal({ isOpen, onClose, posts, centerPost }: MapModalProps) 
 
                 <div className="flex gap-3">
                   <img
-                    src={selectedPost.imageUrl || selectedPost.image_url || "/placeholder.svg"}
+                    src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
                     alt="Issue"
                     className="w-16 h-16 rounded-lg object-cover bg-gray-100 flex-shrink-0"
                   />

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { X, RefreshCw, AlertCircle, Heart, Plus, Clock, Gift, Earth, Map, Timer } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Post } from "@/lib/types"
+import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatSatsValue, formatTimeAgo } from "@/lib/utils"
 import { useAuth } from "@/components/auth-provider"
 import { loadGoogleMaps } from "@/lib/google-maps-loader"
@@ -1225,7 +1226,7 @@ function MapViewComponent({
 
             <div className="flex gap-3">
               <img
-                src={selectedPost.imageUrl || selectedPost.image_url || "/placeholder.svg"}
+                src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
                 alt="Issue"
                 className="w-16 h-16 rounded-lg object-cover bg-gray-100 flex-shrink-0"
               />

--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardFooter } from "@/components/ui/card"
 import type { Post } from "@/lib/types"
+import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatTimeAgo } from "@/lib/utils"
 import { reverseGeocode, getTravelTimes, getCurrentLocationWithName, type TravelTimes } from "@/lib/geocoding"
 import { Car, Footprints, CheckCircle, Clock, Circle, Timer } from "lucide-react"
@@ -343,7 +344,7 @@ export function PostCard({ post, showStatusBadge = false }: { post: Post; showSt
 
   // Get the image URL, handling both imageUrl and image_url properties
   const getImageUrl = () => {
-    return post.imageUrl || post.image_url || (post.has_image === false ? '/images/earth-placeholder.jpg' : '/placeholder.svg')
+    return post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')
   }
 
   const getInitials = () => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const EARTH_PLACEHOLDER_IMAGE = '/images/earth-placeholder.jpg';

--- a/lib/seed/constants.ts
+++ b/lib/seed/constants.ts
@@ -154,10 +154,7 @@ export const PLACEHOLDER_IMAGES = {
   DEVICE: 'https://placehold.co/400x400/png?text=Pet',
 } as const;
 
-/**
- * Earth placeholder image for image-less posts
- */
-export const EARTH_PLACEHOLDER_IMAGE = '/images/earth-placeholder.jpg';
+export { EARTH_PLACEHOLDER_IMAGE } from '@/lib/constants';
 
 /**
  * Reward amounts in sats


### PR DESCRIPTION
## Summary
- Moved `EARTH_PLACEHOLDER_IMAGE` constant from `lib/seed/constants.ts` to a new shared `lib/constants.ts` so production UI components don't import from seed-specific code. The seed file re-exports it for backward compatibility.
- Replaced 4 hardcoded `'/images/earth-placeholder.jpg'` string literals in `post-card.tsx` and `app/post/[id]/page.tsx` with the shared constant.
- Added `has_image === false` earth placeholder fallback to `map-view.tsx` and `map-modal.tsx`, which were missed in PR #67 — previously image-less posts showed the generic `placeholder.svg` on map views.

## Test plan
- [ ] Verify image-less posts show the earth placeholder on the post card, post detail page, map view preview, and map modal preview
- [ ] Verify posts with images still display their actual image
- [ ] Verify existing unit tests pass (`post-card.test.tsx` image handling tests)

Made with [Cursor](https://cursor.com)