### PR TITLE
fix: align expiration button border and icon hover states

### DIFF
--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -1445,7 +1445,7 @@ export default function NewPostPage() {
                   className={`h-12 w-12 flex items-center justify-center rounded-lg border transition-colors ${
                     expiresAt
                       ? 'border-green-600 text-green-600 bg-green-50 dark:bg-green-950/30'
-                      : 'border-gray-300 text-muted-foreground hover:border-gray-400 hover:text-foreground'
+                      : 'border-muted-foreground text-muted-foreground hover:border-white hover:text-white'
                   }`}
                   title={expiresAt ? `Expires ${formatAbbreviatedTimeRemaining(expiresAt)}` : 'Add expiration'}
                 >


### PR DESCRIPTION
## Summary
- Default state: border and icon both use `muted-foreground` (subtle gray) instead of the brighter `gray-300` border
- Hover state: both border and icon transition to white together
- Active (expiration set) state: unchanged, stays green

## Test plan
- [ ] Verify the stopwatch button border is subtle/muted by default (matches the icon color)
- [ ] Hover the button and confirm both border and icon go white simultaneously
- [ ] Set an expiration and confirm both go green

Made with [Cursor](https://cursor.com)