### PR TITLE
perf: lazy-load globe component and code-split map bundles

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -2,8 +2,20 @@
 
 import { useState, useEffect, useMemo, useRef } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
-import { MapView } from "@/components/map-view"
+import dynamic from "next/dynamic"
 import { LoadingSpinner } from "@/components/loading-spinner"
+
+const MapView = dynamic(
+  () => import("@/components/map-view").then((mod) => mod.MapView),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-full h-full bg-gray-100 dark:bg-gray-800 animate-pulse flex items-center justify-center">
+        <span className="text-gray-400">Loading map...</span>
+      </div>
+    ),
+  }
+)
 import { useAuth } from "@/components/auth-provider"
 import { createBrowserSupabaseClient } from "@/lib/supabase"
 import { getCurrentLocationWithName } from "@/lib/geocoding"

--- a/components/donation-modal.tsx
+++ b/components/donation-modal.tsx
@@ -7,8 +7,13 @@ import { Label } from "@/components/ui/label"
 import { createDonationInvoice, checkDonationPayment } from "@/app/actions/donation-actions"
 import QRCode from "@/components/qr-code"
 import { LocationInput } from "@/components/location-input"
-import { MapView } from "@/components/map-view"
+import dynamic from "next/dynamic"
 import { Heart, Bitcoin, Copy, Eye, EyeOff, CheckCircle, Loader2 } from "lucide-react"
+
+const MapView = dynamic(
+  () => import("@/components/map-view").then((mod) => mod.MapView),
+  { ssr: false }
+)
 import { createBrowserSupabaseClient } from "@/lib/supabase"
 import type { Post } from "@/lib/types"
 

--- a/components/globe-map-view.tsx
+++ b/components/globe-map-view.tsx
@@ -25,7 +25,6 @@ interface GlobeMapViewProps {
 // Inactivity timeout before resuming auto-rotation (10 seconds)
 const INACTIVITY_TIMEOUT = 10000
 
-// Dynamic import for globe.gl since it requires window
 const GlobeMapViewComponent = ({
   posts,
   userLocation,
@@ -40,6 +39,8 @@ const GlobeMapViewComponent = ({
   const [selectedPost, setSelectedPost] = useState<Post | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [Globe, setGlobe] = useState<any>(null)
+  const [isVisible, setIsVisible] = useState(true)
+  const wasRotatingBeforePause = useRef(false)
 
   // Load globe.gl dynamically (client-side only)
   useEffect(() => {
@@ -47,6 +48,43 @@ const GlobeMapViewComponent = ({
       setGlobe(() => mod.default)
     })
   }, [])
+
+  // Pause/resume globe rendering based on visibility (IntersectionObserver)
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible(entry.isIntersecting)
+      },
+      { threshold: 0.1 }
+    )
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const globe = globeRef.current
+    if (!globe) return
+
+    const controls = globe.controls()
+    const renderer = globe.renderer?.()
+
+    if (!isVisible) {
+      wasRotatingBeforePause.current = controls.autoRotate
+      controls.autoRotate = false
+      if (renderer) {
+        renderer.setAnimationLoop(null)
+      }
+    } else {
+      controls.autoRotate = wasRotatingBeforePause.current
+      if (renderer) {
+        renderer.setAnimationLoop(() => renderer.render(globe.scene(), globe.camera()))
+      }
+      globe.resumeAnimation?.()
+    }
+  }, [isVisible])
 
   // Memoize posts with valid coordinates to prevent re-renders when typing in search
   const postsWithLocation = useMemo(() => 

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -12,7 +12,19 @@ import { loadGoogleMaps } from "@/lib/google-maps-loader"
 import { createBrowserSupabaseClient } from "@/lib/supabase"
 import { DonationModal } from "@/components/donation-modal"
 import { getCurrentLocationWithName } from "@/lib/geocoding"
-import { GlobeMapView } from "./globe-map-view"
+import dynamic from "next/dynamic"
+
+const GlobeMapView = dynamic(
+  () => import("./globe-map-view").then((mod) => mod.GlobeMapView),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-full h-full flex items-center justify-center bg-background">
+        <div className="w-12 h-12 border-4 border-amber-500/30 border-t-amber-500 rounded-full animate-spin" />
+      </div>
+    ),
+  }
+)
 
 const containerStyle = {
   width: "100%",
@@ -1256,22 +1268,17 @@ function MapViewComponent({
         </div>
       )}
 
-      {/* 3D Globe View - Always rendered for preloading, hidden when not active */}
-      <div 
-        className="absolute inset-0 transition-opacity duration-300"
-        style={{ 
-          opacity: viewMode === "globe" ? 1 : 0,
-          visibility: viewMode === "globe" ? "visible" : "hidden",
-          pointerEvents: viewMode === "globe" ? "auto" : "none"
-        }}
-      >
-        <GlobeMapView
-          posts={postsWithLocation}
-          userLocation={userLocation ? { latitude: userLocation.latitude, longitude: userLocation.longitude } : null}
-          showPreviewCard={showPreviewCard}
-          searchedLocation={searchedLocation}
-        />
-      </div>
+      {/* 3D Globe View - Only mounted when active to avoid continuous WebGL rendering */}
+      {viewMode === "globe" && (
+        <div className="absolute inset-0">
+          <GlobeMapView
+            posts={postsWithLocation}
+            userLocation={userLocation ? { latitude: userLocation.latitude, longitude: userLocation.longitude } : null}
+            showPreviewCard={showPreviewCard}
+            searchedLocation={searchedLocation}
+          />
+        </div>
+      )}
 
       {/* Floating New Issue Button - Hidden on mobile (bottom nav has its own + button), shown on desktop/modal */}
       {!hideSearchOverlay && (


### PR DESCRIPTION
## Summary
- **Globe lazy-mount**: Globe component is now only mounted when `viewMode === "globe"` instead of always being rendered and hidden with CSS. Previously it was continuously running WebGL (~720ms CPU per trace session).
- **IntersectionObserver pause/resume**: When the globe scrolls off-screen, the WebGL animation loop and auto-rotation are halted. They resume when it comes back into view.
- **Code-split with `next/dynamic`**: `globe.gl`/Three.js and Google Maps are now dynamically imported in `map-view.tsx`, `app/map/page.tsx`, and `donation-modal.tsx` so they're only loaded when actually needed.

## Test plan
- [ ] Open flat map view — globe should NOT be mounted (check React DevTools)
- [ ] Switch to globe view — globe loads and renders correctly
- [ ] Switch back to flat — globe unmounts, CPU drops
- [ ] Open `/map` page — map loads correctly (dynamic import)
- [ ] Open donation modal with map — map loads correctly
- [ ] Dashboard map continues to work as before


Made with [Cursor](https://cursor.com)