### PR TITLE
fix: don't notify other devices until wager is selected

### DIFF
--- a/app/api/game/pickleball/create/route.ts
+++ b/app/api/game/pickleball/create/route.ts
@@ -206,7 +206,7 @@ export async function POST(request: NextRequest) {
       .insert({
         host_device_id: deviceId,
         host_user_id: device.user_id,
-        status: "lobby",
+        status: "setup",
         players: [hostPlayer],
         lobby_expires_at: lobbyExpiresAt,
         wager_amount: wagerAmount,

--- a/app/api/game/pickleball/state/route.ts
+++ b/app/api/game/pickleball/state/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
 
     // Check if lobby expired and auto-cancel
     if (
-      game.status === "lobby" &&
+      (game.status === "lobby" || game.status === "setup") &&
       new Date(game.lobby_expires_at) < new Date()
     ) {
       const players = (game.players as any[]) || []
@@ -212,17 +212,20 @@ export async function POST(request: NextRequest) {
         i === 0 ? { ...p, wagerAccepted: wagerAmount > 0 ? true : undefined } : p
       )
 
+      const newExpiry = new Date(Date.now() + 100 * 1000).toISOString()
       await supabase
         .from("pickleball_games")
         .update({
+          status: "lobby",
           wager_amount: wagerAmount,
           wager_status: wagerAmount > 0 ? "active" : "none",
           players: updatedPlayers,
+          lobby_expires_at: newExpiry,
           updated_at: new Date().toISOString(),
         })
         .eq("id", gameId)
 
-      console.log(`[Pickleball] Game ${gameId} wager set to ${wagerAmount} by host`)
+      console.log(`[Pickleball] Game ${gameId} wager set to ${wagerAmount}, status → lobby`)
       return NextResponse.json({ success: true, wagerAmount, wagerStatus: wagerAmount > 0 ? "active" : "none" })
     }
 


### PR DESCRIPTION
## Summary

- Games now start with status `setup` instead of `lobby`
- The config endpoint only looks for `lobby`/`countdown` games, so `setup` games are invisible to other devices
- The `set_wager` action transitions the game to `lobby` status (and resets the 100s expiry timer)
- Stale `setup` games are also cleaned up by the expiry check

## Test plan

- [ ] Host creates game → other devices do NOT get notified during wager selection
- [ ] After host selects wager → game transitions to lobby → other devices see the invite
- [ ] Auto-join still works (only matches lobby-status games)

Made with [Cursor](https://cursor.com)