### PR TITLE
fix: always use fresh GPS location when creating a post

### DIFF
--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -419,7 +419,7 @@ export default function NewPostPage() {
     // Since the photo is being taken right now, the issue is at the user's current location
     setIsGettingLocation(true)
     try {
-      const locationInfo = await getCurrentLocationWithName({ useCache: true }) // Real-time location for post precision; useCache only as fallback on error
+      const locationInfo = await getCurrentLocationWithName({ forceRefresh: true, useCache: false })
 
       if (locationInfo) {
         setCurrentLocation({

--- a/lib/geocoding.ts
+++ b/lib/geocoding.ts
@@ -412,7 +412,11 @@ export async function getCurrentLocationWithName(options?: {
         
         reject(error)
       },
-      { enableHighAccuracy: true, timeout: 10000, maximumAge: 300000 }, // Use 5-minute cache for position
+      {
+        enableHighAccuracy: true,
+        timeout: forceRefresh ? 15000 : 10000,
+        maximumAge: forceRefresh ? 0 : 300000,
+      },
     )
   })
 


### PR DESCRIPTION
## Summary
- Post creation was falling back to a stale cached location (from localStorage) when GPS timed out, causing posts to be tagged with the wrong city (e.g. Danville instead of Anaheim)
- Changed `handleCapture` to use `forceRefresh: true, useCache: false` so it never silently returns a stale cached location
- When `forceRefresh` is true, geolocation now uses `maximumAge: 0` (forces fresh GPS) and `timeout: 15000` (15s instead of 10s to give GPS more time after app opens)

## Test plan
- [ ] Create a post from a new location — should show correct current city, not a previously cached one
- [ ] If GPS times out, post should show no location rather than a wrong cached location
- [ ] "Get Location" button on post detail still works with force refresh

Made with [Cursor](https://cursor.com)