### PR TITLE
fix: clean up post detail UI and restore map controls

### DIFF
--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -23,8 +23,8 @@ import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { reverseGeocode } from "@/lib/geocoding"
 import { uploadImage, generateImagePath, isBase64Image } from "@/lib/storage"
 // Add the new server actions to imports
-import { markPostFixedAnonymouslyAction, submitAnonymousFixForReviewAction, submitLoggedInFixForReviewAction, closeIssueAction, deletePostAction, recordDeviceRejectionAction, updatePostExpirationAction } from "@/app/actions/post-actions"
-import { User, Timer } from "lucide-react"
+import { markPostFixedAnonymouslyAction, submitAnonymousFixForReviewAction, submitLoggedInFixForReviewAction, closeIssueAction, deletePostAction, recordDeviceRejectionAction } from "@/app/actions/post-actions"
+import { User } from "lucide-react"
 import { LightningInvoiceModal } from "@/components/lightning-invoice-modal"
 import { AnonymousFixSubmissionModal } from "@/components/anonymous-fix-submission-modal"
 import { v4 as uuidv4 } from "uuid"
@@ -66,7 +66,6 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
   const supabase = createBrowserSupabaseClient()
   const [displayLocation, setDisplayLocation] = useState<string>("")
   const [isReviewing, setIsReviewing] = useState(false)
-  const [showFullAnalysis, setShowFullAnalysis] = useState(false)
   const [showLightningModal, setShowLightningModal] = useState(false)
   const [showAnonymousFixSubmissionModal, setShowAnonymousFixSubmissionModal] = useState(false)
   const [pendingAnonymousFixPostId, setPendingAnonymousFixPostId] = useState<string | null>(null)
@@ -88,10 +87,6 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
   const [isDeletingPost, setIsDeletingPost] = useState(false)
   const [familyMembers, setFamilyMembers] = useState<{ id: string; username: string; name: string; avatar_url: string | null; balance?: number }[]>([])
   
-  // Expiration management state
-  const [showExpirationEdit, setShowExpirationEdit] = useState(false)
-  const [isSavingExpiration, setIsSavingExpiration] = useState(false)
-  const [editExpiresAt, setEditExpiresAt] = useState<string | null>(null)
   
   // Group admin status - allows group admins to approve fixes for any post in their group
   const [isGroupAdmin, setIsGroupAdmin] = useState(false)
@@ -449,10 +444,6 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
     fetchPost()
   }, [params.id, toast, supabase])
 
-  // Initialize editExpiresAt from post data
-  useEffect(() => {
-    if (post?.expires_at) setEditExpiresAt(post.expires_at)
-  }, [post?.expires_at])
 
   useEffect(() => {
     const handleStorageChange = () => {
@@ -1273,25 +1264,6 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
     }
   }
 
-  // Handle update expiration
-  const handleUpdateExpiration = async (newExpiresAt: string | null) => {
-    const effectiveUserId = activeUserId || user?.id
-    if (!effectiveUserId || !post) return
-    setIsSavingExpiration(true)
-    try {
-      const result = await updatePostExpirationAction(post.id, effectiveUserId, newExpiresAt)
-      if (result.success) {
-        setPost(prev => prev ? { ...prev, expires_at: newExpiresAt } : prev)
-        setEditExpiresAt(newExpiresAt)
-        setShowExpirationEdit(false)
-        toast.success(newExpiresAt ? 'Expiration updated' : 'Expiration removed')
-      } else {
-        toast.error('Error', { description: result.error || 'Failed to update expiration' })
-      }
-    } finally {
-      setIsSavingExpiration(false)
-    }
-  }
 
   // Handle reject device-submitted fix
   // This is for when a fixer was pre-selected (from device email) but the poster determines it's not actually fixed  
@@ -2067,46 +2039,26 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
             </div>
           )}
           
-          {!post.fixed && post.under_review && post.submitted_fix_image_url && (
-            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg mb-6">
-              <div className="flex items-center mb-1">
-                {" "}
-                <p className="text-sm font-medium">AI Review</p>{" "}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {showFullAnalysis ? (
-                  <div>
-                    {post.ai_analysis || "The AI analysis is not available for this submission."}
-                    <button onClick={() => setShowFullAnalysis(false)} className="text-white hover:underline ml-1">
-                      {" "}
-                      Show less{" "}
-                    </button>
-                  </div>
-                ) : (
-                  <div className="line-clamp-3">
-                    {post.ai_analysis && post.ai_analysis.length > 150 ? (
-                      <>
-                        {post.ai_analysis.slice(0, 150)}
-                        <button onClick={() => setShowFullAnalysis(true)} className="text-white hover:underline">
-                          {" "}
-                          ...see more{" "}
-                        </button>
-                      </>
-                    ) : (
-                      post.ai_analysis || "The AI analysis is not available for this submission."
-                    )}
-                  </div>
-                )}
-              </div>
-              {post.ai_confidence_score && (
-                <div className="mt-2 text-xs text-muted-foreground">Confidence Score: {post.ai_confidence_score}/10</div>
-              )}
-            </div>
-          )}
           {post.fixed && post.fixer_note && (
             <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border">
               <h3 className="font-medium mb-2">Fixer's note:</h3>
               <p className="text-sm text-muted-foreground">{post.fixer_note}</p>
+            </div>
+          )}
+          {/* AI Review - only visible to post owner or group admin when a fix is under review */}
+          {!post.fixed &&
+          post.under_review &&
+          post.submitted_fix_image_url &&
+          post.ai_analysis &&
+          user &&
+          post.user_id != null &&
+          (post.userId === user.id || post.user_id === user.id || post.user_id === activeUserId || isGroupAdmin) && (
+            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg mb-6">
+              <p className="text-sm font-medium mb-1">AI Review</p>
+              <p className="text-sm text-muted-foreground whitespace-pre-line">{post.ai_analysis}</p>
+              {post.ai_confidence_score && (
+                <div className="mt-2 text-xs text-muted-foreground">Confidence Score: {post.ai_confidence_score}/10</div>
+              )}
             </div>
           )}
           {/* Check if this is the post owner or group admin viewing a fix under review */}
@@ -2116,7 +2068,6 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
           user &&
           post.user_id != null &&
           (post.userId === user.id || post.user_id === user.id || post.user_id === activeUserId || isGroupAdmin) ? (
-            // Show review interface for post owner or group admin
             <div className="space-y-4 mb-6">
               {post.submitted_fix_note && (
                 <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
@@ -2264,57 +2215,11 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
               }}
             />
           )}
-          {/* Info banner for image-less posts */}
-          {!post.has_image && !post.fixed && !post.under_review && !post.deleted_at && (
-            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg mb-4 text-sm text-muted-foreground">
-              📋 This post has no before photo — your fix will require approval from the original poster.
-            </div>
-          )}
           
           {!post.fixed && !post.under_review && !post.deleted_at && (
             <Button className="w-full h-12 mt-6 bg-green-600 hover:bg-green-700 text-white text-lg font-semibold" onClick={() => setShowCamera(true)}>Start</Button>
           )}
           
-          {/* Expiration management - only visible to original poster */}
-          {isOriginalPoster && !post.fixed && !post.deleted_at && (
-            <div className="mt-4">
-              {post.expires_at && !showExpirationEdit ? (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Timer className="w-4 h-4" />
-                  <span>Expires {formatDistanceToNow(new Date(post.expires_at), { addSuffix: true })}</span>
-                  <button type="button" onClick={() => setShowExpirationEdit(true)}
-                    className="text-xs underline hover:text-foreground">Edit</button>
-                  <button type="button" onClick={() => handleUpdateExpiration(null)}
-                    className="text-xs text-red-500 hover:text-red-600"
-                    disabled={isSavingExpiration}>Remove</button>
-                </div>
-              ) : !post.expires_at && !showExpirationEdit ? (
-                <button type="button" onClick={() => setShowExpirationEdit(true)}
-                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-                  <Timer className="w-3.5 h-3.5" /> Add expiration
-                </button>
-              ) : null}
-              {showExpirationEdit && (
-                <div className="flex flex-wrap gap-2 items-center mt-2">
-                  {[{label:'1 hr',hrs:1},{label:'12 hrs',hrs:12},{label:'1 day',hrs:24},
-                    {label:'3 days',hrs:72},{label:'7 days',hrs:168}].map(({label,hrs}) => (
-                    <button key={label} type="button"
-                      onClick={() => setEditExpiresAt(new Date(Date.now()+hrs*3600_000).toISOString())}
-                      className="px-3 py-1 rounded-full text-xs border border-gray-300 hover:border-gray-400">
-                      {label}
-                    </button>
-                  ))}
-                  <button type="button" onClick={() => handleUpdateExpiration(editExpiresAt)}
-                    disabled={isSavingExpiration}
-                    className="px-3 py-1 rounded-full text-xs bg-green-600 text-white">
-                    {isSavingExpiration ? 'Saving...' : 'Save'}
-                  </button>
-                  <button type="button" onClick={() => setShowExpirationEdit(false)}
-                    className="text-xs text-muted-foreground">Cancel</button>
-                </div>
-              )}
-            </div>
-          )}
           
           {/* Mark Complete button - only visible to original poster */}
           {canCloseIssue && (

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -1281,16 +1281,14 @@ function MapViewComponent({
       )}
 
       {/* Floating New Issue Button - Hidden on mobile (bottom nav has its own + button), shown on desktop/modal */}
-      {!hideSearchOverlay && (
-        <button
-          onClick={onNewIssue || handleNewPost}
-          className={`absolute right-6 z-20 flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:bg-primary/90 transition-all duration-200 transform hover:scale-105 shadow-lg ${isModal ? '' : 'hidden lg:flex'}`}
-          style={{ bottom: isModal ? 24 : BOTTOM_NAV_CLEARANCE }}
-          aria-label="New Issue"
-        >
-          <Plus className="w-6 h-6 text-white stroke-[2.5]" />
-        </button>
-      )}
+      <button
+        onClick={onNewIssue || handleNewPost}
+        className={`absolute right-6 z-20 flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:bg-primary/90 transition-all duration-200 transform hover:scale-105 shadow-lg ${isModal ? '' : 'hidden lg:flex'}`}
+        style={{ bottom: isModal ? 24 : BOTTOM_NAV_CLEARANCE }}
+        aria-label="New Issue"
+      >
+        <Plus className="w-6 h-6 text-white stroke-[2.5]" />
+      </button>
 
       {/* Lower Right Button Stack - Donate + View Mode Toggle
           On mobile (non-modal): sits just above bottom nav (no floating + button on mobile)

--- a/components/post-detail-map.tsx
+++ b/components/post-detail-map.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import React, { useState, useEffect, useRef } from "react"
+import { useRouter } from "next/navigation"
+import { Plus, Gift } from "lucide-react"
 import type { Post } from "@/lib/types"
 import { loadGoogleMaps } from "@/lib/google-maps-loader"
 
@@ -15,6 +17,7 @@ declare global {
 }
 
 function PostDetailMapComponent({ post }: PostDetailMapProps) {
+  const router = useRouter()
   const mapRef = useRef<HTMLDivElement>(null)
   const [mapInstance, setMapInstance] = useState<google.maps.Map | null>(null)
   const [mapInitialized, setMapInitialized] = useState(false)
@@ -239,7 +242,7 @@ function PostDetailMapComponent({ post }: PostDetailMapProps) {
         disableDefaultUI: true,
         zoomControl: true,
         zoomControlOptions: {
-          position: window.google.maps.ControlPosition.RIGHT_CENTER,
+          position: window.google.maps.ControlPosition.RIGHT_BOTTOM,
         },
         styles: [
           {
@@ -280,8 +283,25 @@ function PostDetailMapComponent({ post }: PostDetailMapProps) {
 
   return (
     <div className="relative w-full h-full">
-      {/* Map container with rounded edges */}
       <div ref={mapRef} className="absolute inset-0 rounded-r-xl" />
+
+      {/* Floating action buttons */}
+      <div className="absolute z-20 flex flex-col gap-3 right-6 bottom-6">
+        <button
+          onClick={() => router.push('/donate')}
+          className="flex items-center justify-center w-12 h-12 rounded-full bg-white dark:bg-gray-900/80 dark:backdrop-blur-sm shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 transform hover:scale-105"
+          aria-label="Donate"
+        >
+          <Gift className="w-6 h-6 text-gray-500 dark:text-gray-400" />
+        </button>
+        <button
+          onClick={() => router.push('/post/new')}
+          className="flex items-center justify-center w-14 h-14 rounded-full bg-primary hover:bg-primary/90 transition-all duration-200 transform hover:scale-105 shadow-lg"
+          aria-label="New Issue"
+        >
+          <Plus className="w-6 h-6 text-white stroke-[2.5]" />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Remove AI Review widget from open posts; only show it to post owner / group admins after a fix is submitted for review
- Remove "Add expiration" from post detail view (only belongs in the creation flow)
- Remove informational banner from post detail view
- Add floating New Issue and Donate buttons to the post detail map on desktop
- Reposition zoom controls from RIGHT_CENTER to RIGHT_BOTTOM on post detail map
- Always show the New Issue button on the dashboard map (was incorrectly hidden by the `hideSearchOverlay` flag)

## Test plan
- [ ] Open a post detail page as a non-owner — verify no AI Review widget or Add Expiration option appears
- [ ] Submit a fix on a post, then view as post owner — verify AI Review widget appears alongside the before/after and Approve/Reject buttons
- [ ] On desktop post detail, verify Donate and New Issue floating buttons appear in the lower right of the map
- [ ] On desktop dashboard, verify the green New Issue button is visible in the lower right of the map

Made with [Cursor](https://cursor.com)