### PR TITLE
ui: redesign camera screen buttons and layout

### DIFF
--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -867,7 +867,7 @@ export default function NewPostPage() {
     <div className={step === "photo" && cameraActive ? "" : "container px-4 py-6 mx-auto max-w-md"}>
       {step === "photo" && cameraActive && (
         <>
-          <div className="absolute top-12 left-1/2 transform -translate-x-1/2 z-50">
+          <div className="absolute left-1/2 transform -translate-x-1/2 z-50 flex items-center" style={{ top: `calc(env(safe-area-inset-top, 0px) + 16px)`, height: '40px' }}>
             <div className="bg-black/50 text-white/70 px-4 py-2 rounded-full text-sm font-medium backdrop-blur-sm">
               Take photo of the issue
             </div>
@@ -889,21 +889,12 @@ export default function NewPostPage() {
             key="camera-active"
             onCapture={handleCapture}
             onGalleryClick={() => document.getElementById('photo-upload')?.click()}
+            onSkip={() => {
+              setImage(null)
+              setStep("details")
+              setCameraActive(false)
+            }}
           />
-          {/* Skip photo button */}
-          <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-50">
-            <button
-              type="button"
-              onClick={() => {
-                setImage(null)
-                setStep("details")
-                setCameraActive(false)
-              }}
-              className="text-sm text-white/60 underline hover:text-white/80 transition-colors"
-            >
-              Skip photo
-            </button>
-          </div>
         </>
       ) : (
         <>

--- a/components/camera-capture.tsx
+++ b/components/camera-capture.tsx
@@ -9,10 +9,12 @@ import { useMobile } from "@/hooks/use-mobile"
 
 export function CameraCapture({ 
   onCapture, 
-  onGalleryClick 
+  onGalleryClick,
+  onSkip,
 }: { 
   onCapture: (imageSrc: string) => void
   onGalleryClick?: () => void
+  onSkip?: () => void
 }) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -408,13 +410,13 @@ export function CameraCapture({
               <span className="sr-only">Take Photo</span>
             </Button>
           </div>
-          {/* Back button */}
+          {/* Close button */}
           <Button
             type="button"
             variant="outline"
             size="icon"
             onClick={() => window.history.back()}
-            className="absolute top-6 left-4 bg-black/30 border-0 hover:bg-black/40 text-white/70"
+            className="absolute top-6 left-4 rounded-full bg-black/30 border-0 hover:bg-black/40 text-white/70"
             style={{ top: `calc(env(safe-area-inset-top, 0px) + 16px)` }}
           >
             <svg
@@ -428,9 +430,9 @@ export function CameraCapture({
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <path d="m15 18-6-6 6-6" />
+              <path d="M18 6L6 18M6 6l12 12" />
             </svg>
-            <span className="sr-only">Back</span>
+            <span className="sr-only">Close</span>
           </Button>
           {isMobile && (
             <Button
@@ -438,7 +440,7 @@ export function CameraCapture({
               variant="outline"
               size="icon"
               onClick={switchCamera}
-              className="absolute right-4 bg-black/30 border-0 hover:bg-black/40 text-white/70"
+              className="absolute right-4 rounded-full bg-black/30 border-0 hover:bg-black/40 text-white/70"
               style={{ top: `calc(env(safe-area-inset-top, 0px) + 16px)` }}
             >
               <svg
@@ -458,20 +460,20 @@ export function CameraCapture({
               <span className="sr-only">Switch Camera</span>
             </Button>
           )}
-          {/* Gallery/Upload button - lower right */}
+          {/* Gallery/Upload button - lower left */}
           {onGalleryClick && (
             <Button
               type="button"
               variant="outline"
               size="icon"
               onClick={onGalleryClick}
-              className="absolute right-4 w-16 h-16 bg-black/30 border-0 hover:bg-black/40 text-white/70"
-              style={{ bottom: `calc(env(safe-area-inset-bottom, 0px) + 24px)` }}
+              className="absolute left-4 rounded-full bg-black/30 border-0 hover:bg-black/40 text-white/70"
+              style={{ bottom: `calc(env(safe-area-inset-bottom, 0px) + 32px)` }}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="36"
-                height="36"
+                width="20"
+                height="20"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -484,6 +486,32 @@ export function CameraCapture({
                 <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
               </svg>
               <span className="sr-only">Upload from Gallery</span>
+            </Button>
+          )}
+          {/* Skip button - lower right */}
+          {onSkip && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={onSkip}
+              className="absolute right-4 rounded-full bg-black/30 border-0 hover:bg-black/40 text-white/70"
+              style={{ bottom: `calc(env(safe-area-inset-bottom, 0px) + 32px)` }}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m9 18 6-6-6-6" />
+              </svg>
+              <span className="sr-only">Skip</span>
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Replace back chevron with X close icon (circular) in upper left
- Make all camera overlay buttons circular (close, switch camera, gallery, skip)
- Align "Take photo of the issue" pill vertically with top-row buttons
- Move gallery/upload button from bottom-right to bottom-left with consistent icon sizing
- Add skip button (right chevron) in bottom-right, replacing the centered "Skip photo" text link

## Test plan
- [ ] Open post creation flow on mobile
- [ ] Verify close (X), reverse camera, gallery, and skip buttons are all circular
- [ ] Verify "Take photo of the issue" pill is vertically aligned with close and reverse camera buttons
- [ ] Verify gallery upload button is in bottom-left and opens photo picker
- [ ] Verify skip button is in bottom-right and advances to details step
- [ ] Verify capture button still works in bottom-center

Made with [Cursor](https://cursor.com)