### PR TITLE
ui: redesign imageless posts to show description instead of earth placeholder

### DIFF
--- a/app/actions/post-actions.ts
+++ b/app/actions/post-actions.ts
@@ -609,7 +609,7 @@ export async function createFundedAnonymousPostAction(postDetails: {
         created_by_avatar: null,
         title: postDetails.description.substring(0, 50),
         description: postDetails.description,
-        image_url: postDetails.image_url || "/placeholder.jpg", // Use placeholder only if no image provided
+        image_url: postDetails.image_url || null,
         has_image: postDetails.has_image ?? (postDetails.image_url != null && postDetails.image_url.length > 0),
         location: postDetails.location,
         latitude: postDetails.latitude,

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -19,7 +19,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import type { Post } from "@/lib/types"
-import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
+import { renderTextWithLinks } from "@/lib/linkify"
 import { reverseGeocode } from "@/lib/geocoding"
 import { uploadImage, generateImagePath, isBase64Image } from "@/lib/storage"
 // Add the new server actions to imports
@@ -1706,7 +1706,7 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
         {post && (
           <>
             {/* Desktop: Side-by-side layout | Mobile: Single column */}
-            <div className="lg:flex lg:h-[calc(100vh-64px)] lg:overflow-hidden bg-white dark:bg-gray-900">
+            <div className="min-h-[100dvh] lg:min-h-0 lg:flex lg:h-[calc(100vh-64px)] lg:overflow-hidden bg-white dark:bg-gray-900">
               {/* Left Panel - Post Details (scrollable) */}
               <div className="w-full lg:w-[380px] xl:w-[420px] lg:flex-shrink-0 lg:overflow-y-auto lg:border-r lg:border-gray-200 lg:dark:border-gray-800">
                 <div className="container px-4 pt-4 pb-6 lg:pt-4 lg:pb-8 mx-auto max-w-md lg:max-w-none">
@@ -1723,14 +1723,24 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
               <div>
                 <div 
                   className="relative w-full h-40 overflow-hidden rounded-lg cursor-pointer transition-opacity hover:opacity-90"
-                  onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg'))}
+                  onClick={() => {
+                    if (post.imageUrl || post.image_url) {
+                      openFullscreenImage(post.imageUrl || post.image_url || '/placeholder.svg')
+                    }
+                  }}
                 >
-                  <Image
-                    src={post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
-                    alt="Before"
-                    fill
-                    className="object-cover"
-                  />
+                  {post.has_image === false && !post.imageUrl && !post.image_url ? (
+                    <div className="w-full h-full flex items-center justify-center bg-white dark:bg-gray-800">
+                      <Image src="/favicon.png" alt="Before" width={64} height={64} className="rounded-lg" />
+                    </div>
+                  ) : (
+                    <Image
+                      src={post.imageUrl || post.image_url || '/placeholder.svg'}
+                      alt="Before"
+                      fill
+                      className="object-cover"
+                    />
+                  )}
                   <div className="absolute top-2 left-2">
                     <span className="bg-black/50 text-white text-xs px-2 py-1 rounded">Before</span>
                   </div>
@@ -1807,13 +1817,76 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
                 </div>
               </div>
             </div>
+          ) : !post.imageUrl && !post.image_url && post.has_image === false ? (
+            <div className="mb-4">
+              {/* Action buttons row - not overlaid since there's no image */}
+              <div className="flex justify-end gap-2 mb-3">
+                <Button 
+                  variant="ghost" 
+                  size="icon" 
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleShare()
+                  }}
+                  className="bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 p-2"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                    <polyline points="16 6 12 2 8 6" />
+                    <line x1="12" x2="12" y1="2" y2="15" />
+                  </svg>
+                  <span className="sr-only">Share</span>
+                </Button>
+                <Button 
+                  variant="ghost" 
+                  size="icon" 
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    router.push("/dashboard")
+                  }}
+                  className="bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 p-2"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M18 6 6 18" />
+                    <path d="m6 6 12 12" />
+                  </svg>
+                  <span className="sr-only">Close</span>
+                </Button>
+              </div>
+              {/* Description text in place of image */}
+              <div className="p-5 bg-gray-900 rounded-lg">
+                <p className="text-white text-lg leading-relaxed" style={{ overflowWrap: 'anywhere' }}>
+                  {renderTextWithLinks(post.title)}
+                </p>
+              </div>
+            </div>
           ) : (
             <div 
               className="relative w-full h-64 mb-4 overflow-hidden rounded-lg cursor-pointer transition-opacity hover:opacity-95"
-              onClick={() => openFullscreenImage(post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg'))}
+              onClick={() => openFullscreenImage(post.imageUrl || post.image_url || '/placeholder.svg')}
             >
               <Image
-                src={post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
+                src={post.imageUrl || post.image_url || '/placeholder.svg'}
                 alt={post.title}
                 fill
                 className="object-cover"
@@ -1876,7 +1949,9 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
           )}
           <div className="mb-8 flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">
-              <h2 className="text-xl font-bold mb-1">{post.title}</h2>
+              {!(post.has_image === false && !post.imageUrl && !post.image_url) && (
+                <h2 className="text-xl font-bold mb-1" style={{ overflowWrap: 'anywhere' }}>{renderTextWithLinks(post.title)}</h2>
+              )}
               <div className="flex flex-col gap-1">
               {/* First line: Status, Time ago, and Creator */}
               <div className="flex items-center text-sm text-muted-foreground flex-wrap gap-x-2">

--- a/components/map-modal.tsx
+++ b/components/map-modal.tsx
@@ -8,7 +8,6 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { Loader2, X, RefreshCw, MapPin, AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Post } from "@/lib/types"
-import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatSatsValue, formatTimeAgo } from "@/lib/utils"
 import { loadGoogleMaps } from "@/lib/google-maps-loader"
 
@@ -481,9 +480,9 @@ export function MapModal({ isOpen, onClose, posts, centerPost }: MapModalProps) 
 
                 <div className="flex gap-3">
                   <img
-                    src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
+                    src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/favicon.png' : '/placeholder.svg')}
                     alt="Issue"
-                    className="w-16 h-16 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+                    className={`w-16 h-16 rounded-lg flex-shrink-0 ${selectedPost.has_image === false && !selectedPost.imageUrl && !selectedPost.image_url ? 'object-contain p-2 bg-white' : 'object-cover bg-gray-100'}`}
                   />
                   <div className="flex-1 min-w-0 pr-6">
                     <p className="font-medium text-sm text-gray-900 line-clamp-2 mb-2">

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation"
 import { X, RefreshCw, AlertCircle, Heart, Plus, Clock, Gift, Earth, Map, Timer } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Post } from "@/lib/types"
-import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatSatsValue, formatTimeAgo } from "@/lib/utils"
 import { useAuth } from "@/components/auth-provider"
 import { loadGoogleMaps } from "@/lib/google-maps-loader"
@@ -1238,9 +1237,9 @@ function MapViewComponent({
 
             <div className="flex gap-3">
               <img
-                src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')}
+                src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/favicon.png' : '/placeholder.svg')}
                 alt="Issue"
-                className="w-16 h-16 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+                className={`w-16 h-16 rounded-lg flex-shrink-0 ${selectedPost.has_image === false && !selectedPost.imageUrl && !selectedPost.image_url ? 'object-contain p-2 bg-white' : 'object-cover bg-gray-100'}`}
               />
               <div className="flex-1 min-w-0 pr-6">
                 <p className="font-medium text-lg text-gray-900 line-clamp-2 mb-2">

--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -4,8 +4,8 @@ import React, { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardFooter } from "@/components/ui/card"
 import type { Post } from "@/lib/types"
-import { EARTH_PLACEHOLDER_IMAGE } from "@/lib/constants"
 import { formatTimeAgo } from "@/lib/utils"
+import { renderTextWithLinks } from "@/lib/linkify"
 import { reverseGeocode, getTravelTimes, getCurrentLocationWithName, type TravelTimes } from "@/lib/geocoding"
 import { Car, Footprints, CheckCircle, Clock, Circle, Timer } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
@@ -342,9 +342,11 @@ export function PostCard({ post, showStatusBadge = false }: { post: Post; showSt
     return `expires ${Math.floor(diff / 604800)}w`
   }
 
+  const isImageless = !post.imageUrl && !post.image_url && post.has_image === false
+
   // Get the image URL, handling both imageUrl and image_url properties
   const getImageUrl = () => {
-    return post.imageUrl || post.image_url || (post.has_image === false ? EARTH_PLACEHOLDER_IMAGE : '/placeholder.svg')
+    return post.imageUrl || post.image_url || '/placeholder.svg'
   }
 
   const getInitials = () => {
@@ -365,7 +367,13 @@ export function PostCard({ post, showStatusBadge = false }: { post: Post; showSt
         onMouseEnter={handleMouseEnter}
       >
         <div className="relative w-full h-48">
-          {imageError ? (
+          {isImageless ? (
+            <div className="w-full h-full flex items-start p-5 bg-gray-900 rounded-t-2xl">
+              <p className="text-white text-base leading-relaxed line-clamp-5">
+                {renderTextWithLinks(post.description)}
+              </p>
+            </div>
+          ) : imageError ? (
             <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -411,10 +419,12 @@ export function PostCard({ post, showStatusBadge = false }: { post: Post; showSt
           <div className="flex items-start justify-between w-full h-full">
             {/* Left side: Fixed positioned content to prevent shifting */}
             <div className="flex-1 relative h-full">
-              {/* Description - fixed position */}
-              <div className="absolute top-0 left-0 right-0 pr-4">
-                <p className="text-base truncate">{post.description}</p>
-              </div>
+              {/* Description - fixed position (hidden for imageless posts since text is in image area) */}
+              {!isImageless && (
+                <div className="absolute top-0 left-0 right-0 pr-4">
+                  <p className="text-base truncate">{renderTextWithLinks(post.description)}</p>
+                </div>
+              )}
 
               {/* Location and Travel Times row - fixed position */}
               <div className="absolute top-9 left-0 right-0 flex items-center overflow-hidden">

--- a/lib/linkify.tsx
+++ b/lib/linkify.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+
+export function renderTextWithLinks(text: string) {
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const parts = text.split(urlRegex)
+  return parts.map((part, i) => {
+    if (/^https?:\/\//.test(part)) {
+      return (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      )
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>
+  })
+}

--- a/supabase/migrations/20260226000002_make_image_url_nullable.sql
+++ b/supabase/migrations/20260226000002_make_image_url_nullable.sql
@@ -1,0 +1,5 @@
+-- Make image_url nullable to support image-less posts
+-- This was missing from the original image-less posts feature (PR 63)
+-- The has_image column (added in 20260226000000) tracks whether a post has an image
+
+ALTER TABLE posts ALTER COLUMN image_url DROP NOT NULL;

--- a/tests/unit/actions/post-actions.test.ts
+++ b/tests/unit/actions/post-actions.test.ts
@@ -196,7 +196,7 @@ describe('createFundedAnonymousPostAction', () => {
 
       // ASSERT
       expect(result.success).toBe(true)
-      expect(capturedPostInsert.image_url).toBe('/placeholder.jpg')
+      expect(capturedPostInsert.image_url).toBeNull()
     })
 
     it('should use provided image_url when not null', async () => {

--- a/tests/unit/components/post-card.test.tsx
+++ b/tests/unit/components/post-card.test.tsx
@@ -55,7 +55,7 @@ const mockPost: Post = {
 }
 
 describe('PostCard image handling', () => {
-  it('should use Earth placeholder when has_image is false and image_url is null', () => {
+  it('should show description text instead of image when has_image is false and image_url is null', () => {
     const postWithoutImage: Post = {
       ...mockPost,
       image_url: null,
@@ -63,13 +63,13 @@ describe('PostCard image handling', () => {
     }
 
     const { container } = render(<PostCard post={postWithoutImage} />)
-    const img = container.querySelector('img')
+    const textArea = container.querySelector('.bg-gray-900')
     
-    expect(img).toBeTruthy()
-    expect(img?.src).toContain('/images/earth-placeholder.jpg')
+    expect(textArea).toBeTruthy()
+    expect(textArea?.textContent).toContain(postWithoutImage.description)
   })
 
-  it('should use Earth placeholder when has_image is false and image_url is empty string', () => {
+  it('should show description text instead of image when has_image is false and image_url is empty string', () => {
     const postWithoutImage: Post = {
       ...mockPost,
       image_url: '',
@@ -77,10 +77,10 @@ describe('PostCard image handling', () => {
     }
 
     const { container } = render(<PostCard post={postWithoutImage} />)
-    const img = container.querySelector('img')
+    const textArea = container.querySelector('.bg-gray-900')
     
-    expect(img).toBeTruthy()
-    expect(img?.src).toContain('/images/earth-placeholder.jpg')
+    expect(textArea).toBeTruthy()
+    expect(textArea?.textContent).toContain(postWithoutImage.description)
   })
 
   it('should use generic placeholder when has_image is true and image_url is null', () => {


### PR DESCRIPTION
## Summary
- **Feed cards**: Image-less posts now show the description text in the image area (dark bg, white text with line-clamp) instead of the earth placeholder. The description field below is hidden to avoid duplication.
- **Map preview cards**: Image-less posts use the Ganamos logo instead of the earth image.
- **Detail page**: Image-less posts show share/close buttons in a standalone row, with the description text below (not overlaid). The title h2 is hidden since the text is already shown above.
- **URLs**: Descriptions containing URLs are now clickable with semibold styling (no blue color).
- **Truncation fix**: Long URLs on the detail page no longer bleed behind the bitcoin reward icon (`overflow-wrap: anywhere`).
- **Background fix**: Detail page background color now extends full screen height on mobile (`min-h-[100dvh]`).

## Test plan
- [ ] Create an image-less post and verify the description appears in the card image area in the dashboard feed
- [ ] Verify the description is not duplicated in the card footer
- [ ] Open an image-less post on the map and verify the Ganamos logo appears in the preview card
- [ ] Open the detail page for an image-less post and verify buttons are in a row above the description text
- [ ] Verify URLs in descriptions are clickable and styled semibold (not blue)
- [ ] Verify long URLs don't overflow behind the bitcoin icon on the detail page
- [ ] Verify the detail page background color extends to the bottom of the screen on mobile
- [ ] Verify posts WITH images still display normally everywhere


Made with [Cursor](https://cursor.com)