### PR TITLE
fix: anchor send-to modal at top so typeahead results expand downward

### DIFF
--- a/app/wallet/withdraw/page.tsx
+++ b/app/wallet/withdraw/page.tsx
@@ -862,7 +862,7 @@ function WithdrawPageContent() {
 
           {/* Simple Input Modal - No complex components */}
           {showPasteInput && (
-            <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+            <div className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center pt-[15vh] p-4">
               <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- The send-to modal was vertically centered (`items-center`), causing it to shift up/down as typeahead results appeared or changed count
- Changed to `items-start` with a fixed `pt-[15vh]` top offset so the modal stays pinned and only expands downward

## Test plan
- [ ] Open wallet → Send, type a username — modal should stay in place as results appear
- [ ] Verify modal positioning looks good on mobile and desktop viewports

Made with [Cursor](https://cursor.com)