### PR TITLE
feat: L402-based approve/reject endpoints for agent-managed posts

### DIFF
--- a/app/api/posts/[id]/approve/route.ts
+++ b/app/api/posts/[id]/approve/route.ts
@@ -1,0 +1,241 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyL402Token, parseL402Header } from '@/lib/l402'
+import { createServerSupabaseClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/posts/[id]/approve - Poster agent approves a submitted fix
+ *
+ * The poster uses their original L402 token (from POST /api/posts) to approve
+ * a fix that's been submitted for review. If the fixer provided a payout_invoice,
+ * the reward is paid out automatically via Lightning.
+ *
+ * Authentication: The L402 token's payment_hash must match the post's funding_r_hash.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params
+
+  try {
+    const authHeader = request.headers.get('Authorization')
+
+    if (!authHeader) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token required. Use the same token from your original POST /api/posts payment.' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const l402Token = parseL402Header(authHeader)
+    if (!l402Token) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'Invalid Authorization header format. Expected: L402 <macaroon>:<preimage>' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const verification = await verifyL402Token(l402Token, { skipExpiry: true })
+    if (!verification.success) {
+      return corsResponse(
+        NextResponse.json(
+          { error: `L402 verification failed: ${verification.error}` },
+          { status: 401 }
+        )
+      )
+    }
+
+    const supabase = createServerSupabaseClient()
+
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select(`
+        id, reward, fixed, under_review, deleted_at,
+        submitted_fix_at, submitted_fix_by_name, submitted_fix_proof_text,
+        submitted_fix_image_url, submitted_fix_note,
+        submitted_fix_payout_invoice, submitted_fix_lightning_address,
+        funding_r_hash
+      `)
+      .eq('id', postId)
+      .single()
+
+    if (postError || !post) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post not found' }, { status: 404 })
+      )
+    }
+
+    if (post.funding_r_hash !== verification.paymentHash) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token does not match this post. You can only approve fixes on posts you created.' },
+          { status: 403 }
+        )
+      )
+    }
+
+    if (post.deleted_at) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post has been deleted' }, { status: 409 })
+      )
+    }
+
+    if (post.fixed) {
+      return corsResponse(
+        NextResponse.json({ error: 'Fix has already been approved' }, { status: 409 })
+      )
+    }
+
+    if (!post.under_review) {
+      return corsResponse(
+        NextResponse.json({ error: 'No fix is currently submitted for review' }, { status: 409 })
+      )
+    }
+
+    const nowIso = new Date().toISOString()
+    const { error: updateError } = await supabase
+      .from('posts')
+      .update({
+        fixed: true,
+        fixed_at: nowIso,
+        under_review: false,
+        fixed_image_url: post.submitted_fix_image_url,
+        fix_proof_text: post.submitted_fix_proof_text,
+        fixer_note: post.submitted_fix_note,
+      })
+      .eq('id', postId)
+
+    if (updateError) {
+      console.error('Error approving fix:', updateError)
+      return corsResponse(
+        NextResponse.json({ error: 'Failed to approve fix' }, { status: 500 })
+      )
+    }
+
+    const response: Record<string, unknown> = {
+      success: true,
+      post_id: postId,
+      message: 'Fix approved successfully.',
+      approved_at: nowIso,
+    }
+
+    // Pay the fixer if they provided a payout invoice or lightning address
+    const payoutTarget = post.submitted_fix_payout_invoice || post.submitted_fix_lightning_address
+    if (payoutTarget && post.reward > 0) {
+      try {
+        const payoutResult = await payFixer(postId, payoutTarget, post.reward, supabase)
+        response.reward_paid = payoutResult.success
+        if (payoutResult.success) {
+          response.reward_payment_hash = payoutResult.paymentHash
+          response.message = `Fix approved and ${post.reward} sat reward paid to fixer.`
+        } else {
+          response.reward_error = payoutResult.error
+          response.message = `Fix approved but reward payout failed: ${payoutResult.error}`
+        }
+      } catch (err) {
+        console.error('Error paying fixer:', err)
+        response.reward_paid = false
+        response.reward_error = 'Unexpected error during payout'
+        response.message = 'Fix approved but reward payout encountered an error.'
+      }
+    } else {
+      response.reward_paid = false
+      response.message = 'Fix approved. No payout invoice was provided by the fixer.'
+    }
+
+    return corsResponse(NextResponse.json(response))
+  } catch (error) {
+    console.error('Error in POST /api/posts/[id]/approve:', error)
+    return corsResponse(
+      NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    )
+  }
+}
+
+async function payFixer(
+  postId: string,
+  payoutTarget: string,
+  reward: number,
+  supabase: ReturnType<typeof createServerSupabaseClient>,
+): Promise<{ success: boolean; paymentHash?: string; error?: string }> {
+  const trimmed = payoutTarget.trim().toLowerCase()
+  let invoiceToPay = trimmed
+
+  // Lightning address -> invoice conversion
+  if (trimmed.includes('@') && trimmed.includes('.')) {
+    const [user, domain] = trimmed.split('@')
+    const lookupUrl = `https://${domain}/.well-known/lnurlp/${user}`
+
+    const lookupResponse = await fetch(lookupUrl)
+    if (!lookupResponse.ok) {
+      return { success: false, error: 'Failed to lookup Lightning address' }
+    }
+
+    const lookupData = await lookupResponse.json()
+    if (!lookupData.callback) {
+      return { success: false, error: 'Invalid Lightning address response' }
+    }
+
+    const callbackUrl = new URL(lookupData.callback)
+    callbackUrl.searchParams.set('amount', (reward * 1000).toString())
+
+    const invoiceResponse = await fetch(callbackUrl.toString())
+    if (!invoiceResponse.ok) {
+      return { success: false, error: 'Failed to generate invoice from Lightning address' }
+    }
+
+    const invoiceData = await invoiceResponse.json()
+    if (!invoiceData.pr) {
+      return { success: false, error: 'Invalid invoice response from Lightning address' }
+    }
+
+    invoiceToPay = invoiceData.pr
+  }
+
+  const { payInvoice } = await import('@/lib/lightning')
+  const paymentResult = await payInvoice(invoiceToPay)
+
+  if (!paymentResult.success) {
+    return { success: false, error: 'Lightning payment failed' }
+  }
+
+  const now = new Date().toISOString()
+  await supabase
+    .from('posts')
+    .update({
+      anonymous_reward_paid_at: now,
+      anonymous_reward_payment_hash: paymentResult.paymentHash || paymentResult.paymentPreimage,
+    })
+    .eq('id', postId)
+
+  return { success: true, paymentHash: paymentResult.paymentHash || paymentResult.paymentPreimage }
+}
+
+function corsResponse(response: NextResponse): NextResponse {
+  if (process.env.NODE_ENV === 'development') {
+    response.headers.set('Access-Control-Allow-Origin', '*')
+    response.headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  }
+  return response
+}
+
+export async function OPTIONS() {
+  if (process.env.NODE_ENV === 'development') {
+    return new NextResponse(null, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    })
+  }
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/posts/[id]/reject/route.ts
+++ b/app/api/posts/[id]/reject/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyL402Token, parseL402Header } from '@/lib/l402'
+import { createServerSupabaseClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/posts/[id]/reject - Poster agent rejects a submitted fix
+ *
+ * The poster uses their original L402 token (from POST /api/posts) to reject
+ * a fix that's been submitted for review. This reopens the post for new submissions.
+ *
+ * Authentication: The L402 token's payment_hash must match the post's funding_r_hash.
+ *
+ * Optional request body:
+ * { "reason": "The fix doesn't address the issue" }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params
+
+  try {
+    const authHeader = request.headers.get('Authorization')
+
+    if (!authHeader) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token required. Use the same token from your original POST /api/posts payment.' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const l402Token = parseL402Header(authHeader)
+    if (!l402Token) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'Invalid Authorization header format. Expected: L402 <macaroon>:<preimage>' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const verification = await verifyL402Token(l402Token, { skipExpiry: true })
+    if (!verification.success) {
+      return corsResponse(
+        NextResponse.json(
+          { error: `L402 verification failed: ${verification.error}` },
+          { status: 401 }
+        )
+      )
+    }
+
+    const supabase = createServerSupabaseClient()
+
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select(`
+        id, fixed, under_review, deleted_at, funding_r_hash,
+        submitted_fix_payment_hash
+      `)
+      .eq('id', postId)
+      .single()
+
+    if (postError || !post) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post not found' }, { status: 404 })
+      )
+    }
+
+    if (post.funding_r_hash !== verification.paymentHash) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token does not match this post. You can only reject fixes on posts you created.' },
+          { status: 403 }
+        )
+      )
+    }
+
+    if (post.deleted_at) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post has been deleted' }, { status: 409 })
+      )
+    }
+
+    if (post.fixed) {
+      return corsResponse(
+        NextResponse.json({ error: 'Fix has already been approved and cannot be rejected' }, { status: 409 })
+      )
+    }
+
+    if (!post.under_review) {
+      return corsResponse(
+        NextResponse.json({ error: 'No fix is currently submitted for review' }, { status: 409 })
+      )
+    }
+
+    // Parse optional rejection reason
+    let reason: string | null = null
+    try {
+      const body = await request.json()
+      if (body.reason && typeof body.reason === 'string') {
+        reason = body.reason.substring(0, 500)
+      }
+    } catch {
+      // No body or invalid JSON — that's fine, reason is optional
+    }
+
+    const { error: updateError } = await supabase
+      .from('posts')
+      .update({
+        under_review: false,
+        submitted_fix_by_id: null,
+        submitted_fix_by_name: null,
+        submitted_fix_by_avatar: null,
+        submitted_fix_at: null,
+        submitted_fix_image_url: null,
+        submitted_fix_note: null,
+        submitted_fix_proof_text: null,
+        submitted_fix_payment_hash: null,
+        submitted_fix_payout_invoice: null,
+        submitted_fix_lightning_address: null,
+        ai_confidence_score: null,
+        ai_analysis: null,
+      })
+      .eq('id', postId)
+
+    if (updateError) {
+      console.error('Error rejecting fix:', updateError)
+      return corsResponse(
+        NextResponse.json({ error: 'Failed to reject fix' }, { status: 500 })
+      )
+    }
+
+    return corsResponse(
+      NextResponse.json({
+        success: true,
+        post_id: postId,
+        message: 'Fix rejected. The post is now open for new submissions.',
+        reason,
+      })
+    )
+  } catch (error) {
+    console.error('Error in POST /api/posts/[id]/reject:', error)
+    return corsResponse(
+      NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    )
+  }
+}
+
+function corsResponse(response: NextResponse): NextResponse {
+  if (process.env.NODE_ENV === 'development') {
+    response.headers.set('Access-Control-Allow-Origin', '*')
+    response.headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  }
+  return response
+}
+
+export async function OPTIONS() {
+  if (process.env.NODE_ENV === 'development') {
+    return new NextResponse(null, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    })
+  }
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -257,6 +257,8 @@ export async function GET(request: NextRequest) {
     endpoints: {
       'POST /api/posts': 'Create a new post (requires L402 payment)',
       'GET /api/posts/{id}': 'Poll post status (reuse your L402 token, no extra payment)',
+      'POST /api/posts/{id}/approve': 'Approve a submitted fix (reuse your L402 token)',
+      'POST /api/posts/{id}/reject': 'Reject a submitted fix (reuse your L402 token, optional { reason })',
       'GET /api/posts': 'API docs (this page)',
     },
     l402_info: {
@@ -266,7 +268,8 @@ export async function GET(request: NextRequest) {
       currency: 'satoshis',
       documentation: 'https://docs.lightning.engineering/the-lightning-network/l402'
     },
-    status_polling: 'After creating a post, reuse your L402 token (Authorization header) to GET /api/posts/{id} for status updates (fix submissions, approvals). No additional payment required — the token is a persistent bearer instrument.',
+    status_polling: 'After creating a post, reuse your L402 token (Authorization header) to GET /api/posts/{id} for status updates. No additional payment required — the token is a persistent bearer instrument.',
+    fix_management: 'When a fix is submitted (status changes to under_review), use POST /api/posts/{id}/approve or POST /api/posts/{id}/reject to manage it. Approval triggers automatic reward payout if the fixer provided a payout_invoice.',
   })
   
   // Add CORS headers for development only

--- a/tests/unit/approve-api.test.ts
+++ b/tests/unit/approve-api.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/l402', () => ({
+  verifyL402Token: vi.fn(),
+  parseL402Header: vi.fn(),
+}))
+
+vi.mock('@/lib/lightning', () => ({
+  createInvoice: vi.fn(),
+  checkInvoice: vi.fn(),
+  payInvoice: vi.fn(),
+}))
+
+const mockSingle = vi.fn()
+const mockEq = vi.fn().mockReturnThis()
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) })
+mockEq.mockImplementation(() => ({
+  eq: mockEq,
+  single: mockSingle,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  createServerSupabaseClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: mockSelect,
+      update: mockUpdate,
+    })),
+  })),
+}))
+
+import * as l402 from '@/lib/l402'
+
+const MOCK_PAYMENT_HASH = 'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456'
+
+function createMockRequest(withAuth = true) {
+  const headers = new Headers()
+  if (withAuth) {
+    headers.set('Authorization', 'L402 mock-macaroon:mock-preimage')
+  }
+  return new NextRequest('http://localhost:3000/api/posts/test-post-id/approve', {
+    method: 'POST',
+    headers,
+  })
+}
+
+function mockL402Success(paymentHash = MOCK_PAYMENT_HASH) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: true,
+    paymentHash,
+  })
+}
+
+function mockL402Failure(error: string) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: false,
+    error,
+  })
+}
+
+function mockPostData(overrides: Record<string, unknown> = {}) {
+  mockSingle.mockResolvedValue({
+    data: {
+      id: 'test-post-id',
+      reward: 1000,
+      fixed: false,
+      under_review: true,
+      deleted_at: null,
+      submitted_fix_at: '2026-03-04T12:00:00Z',
+      submitted_fix_by_name: 'Agent Fixer',
+      submitted_fix_proof_text: 'https://example.com/proof',
+      submitted_fix_image_url: null,
+      submitted_fix_note: 'Fixed the issue',
+      submitted_fix_payout_invoice: null,
+      submitted_fix_lightning_address: null,
+      funding_r_hash: MOCK_PAYMENT_HASH,
+      ...overrides,
+    },
+    error: null,
+  })
+}
+
+describe('POST /api/posts/[id]/approve - Poster Approves Fix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('Authentication', () => {
+    it('should return 401 when no Authorization header is provided', async () => {
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(false)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('L402 token required')
+    })
+
+    it('should return 401 when L402 header is malformed', async () => {
+      vi.mocked(l402.parseL402Header).mockReturnValue(null)
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('Invalid Authorization header format')
+    })
+
+    it('should return 401 when L402 token verification fails', async () => {
+      mockL402Failure('Invoice not paid')
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('Invoice not paid')
+    })
+
+    it('should call verifyL402Token with skipExpiry: true', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+
+      expect(l402.verifyL402Token).toHaveBeenCalledWith(
+        expect.any(Object),
+        { skipExpiry: true }
+      )
+    })
+  })
+
+  describe('Authorization', () => {
+    it('should return 403 when payment hash does not match', async () => {
+      mockL402Success('different-payment-hash')
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.error).toContain('does not match this post')
+    })
+  })
+
+  describe('Post Not Found', () => {
+    it('should return 404 when post does not exist', async () => {
+      mockL402Success()
+      mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'nonexistent-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('Post not found')
+    })
+  })
+
+  describe('State Validation', () => {
+    it('should return 409 when post is deleted', async () => {
+      mockL402Success()
+      mockPostData({ deleted_at: '2026-03-04T16:00:00Z' })
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('deleted')
+    })
+
+    it('should return 409 when fix is already approved', async () => {
+      mockL402Success()
+      mockPostData({ fixed: true })
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already been approved')
+    })
+
+    it('should return 409 when no fix is under review', async () => {
+      mockL402Success()
+      mockPostData({ under_review: false })
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('No fix is currently submitted')
+    })
+  })
+
+  describe('Successful Approval', () => {
+    it('should approve fix and return success (no payout invoice)', async () => {
+      mockL402Success()
+      mockPostData({ submitted_fix_payout_invoice: null, submitted_fix_lightning_address: null })
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.post_id).toBe('test-post-id')
+      expect(data.approved_at).toBeDefined()
+      expect(data.reward_paid).toBe(false)
+      expect(data.message).toContain('No payout invoice')
+    })
+
+    it('should approve fix and attempt payout when payout_invoice is provided', async () => {
+      mockL402Success()
+      mockPostData({ submitted_fix_payout_invoice: 'lnbc1000n1test' })
+
+      const lightning = await import('@/lib/lightning')
+      vi.mocked(lightning.payInvoice).mockResolvedValue({
+        success: true,
+        paymentHash: 'paid-hash-123',
+      } as any)
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reward_paid).toBe(true)
+      expect(data.reward_payment_hash).toBe('paid-hash-123')
+      expect(data.message).toContain('reward paid')
+    })
+
+    it('should approve fix but report payout failure gracefully', async () => {
+      mockL402Success()
+      mockPostData({ submitted_fix_payout_invoice: 'lnbc1000n1test' })
+
+      const lightning = await import('@/lib/lightning')
+      vi.mocked(lightning.payInvoice).mockResolvedValue({
+        success: false,
+        error: 'Insufficient balance',
+      } as any)
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reward_paid).toBe(false)
+      expect(data.message).toContain('payout failed')
+    })
+  })
+})

--- a/tests/unit/helpers/posts-api-mocks.ts
+++ b/tests/unit/helpers/posts-api-mocks.ts
@@ -383,6 +383,8 @@ export function expectApiDocumentationResponse(data: any) {
   expect(data.endpoints).toHaveProperty('POST /api/posts')
   expect(data.endpoints).toHaveProperty('GET /api/posts')
   expect(data.endpoints).toHaveProperty('GET /api/posts/{id}')
+  expect(data.endpoints).toHaveProperty('POST /api/posts/{id}/approve')
+  expect(data.endpoints).toHaveProperty('POST /api/posts/{id}/reject')
   
   // Verify L402 info structure
   expect(data.l402_info).toMatchObject({

--- a/tests/unit/reject-api.test.ts
+++ b/tests/unit/reject-api.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/l402', () => ({
+  verifyL402Token: vi.fn(),
+  parseL402Header: vi.fn(),
+}))
+
+vi.mock('@/lib/lightning', () => ({
+  createInvoice: vi.fn(),
+  checkInvoice: vi.fn(),
+}))
+
+const mockSingle = vi.fn()
+const mockEq = vi.fn().mockReturnThis()
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) })
+mockEq.mockImplementation(() => ({
+  eq: mockEq,
+  single: mockSingle,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  createServerSupabaseClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: mockSelect,
+      update: mockUpdate,
+    })),
+  })),
+}))
+
+import * as l402 from '@/lib/l402'
+
+const MOCK_PAYMENT_HASH = 'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456'
+
+function createMockRequest(withAuth = true, body?: Record<string, unknown>) {
+  const headers = new Headers()
+  if (withAuth) {
+    headers.set('Authorization', 'L402 mock-macaroon:mock-preimage')
+  }
+  const init: RequestInit = { method: 'POST', headers }
+  if (body) {
+    headers.set('Content-Type', 'application/json')
+    init.body = JSON.stringify(body)
+  }
+  return new NextRequest('http://localhost:3000/api/posts/test-post-id/reject', init)
+}
+
+function mockL402Success(paymentHash = MOCK_PAYMENT_HASH) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: true,
+    paymentHash,
+  })
+}
+
+function mockL402Failure(error: string) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: false,
+    error,
+  })
+}
+
+function mockPostData(overrides: Record<string, unknown> = {}) {
+  mockSingle.mockResolvedValue({
+    data: {
+      id: 'test-post-id',
+      fixed: false,
+      under_review: true,
+      deleted_at: null,
+      funding_r_hash: MOCK_PAYMENT_HASH,
+      submitted_fix_payment_hash: 'fixer-payment-hash',
+      ...overrides,
+    },
+    error: null,
+  })
+}
+
+describe('POST /api/posts/[id]/reject - Poster Rejects Fix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('Authentication', () => {
+    it('should return 401 when no Authorization header is provided', async () => {
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(false)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('L402 token required')
+    })
+
+    it('should return 401 when L402 header is malformed', async () => {
+      vi.mocked(l402.parseL402Header).mockReturnValue(null)
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('Invalid Authorization header format')
+    })
+
+    it('should return 401 when L402 token verification fails', async () => {
+      mockL402Failure('Invoice not paid')
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('Invoice not paid')
+    })
+
+    it('should call verifyL402Token with skipExpiry: true', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+
+      expect(l402.verifyL402Token).toHaveBeenCalledWith(
+        expect.any(Object),
+        { skipExpiry: true }
+      )
+    })
+  })
+
+  describe('Authorization', () => {
+    it('should return 403 when payment hash does not match', async () => {
+      mockL402Success('different-payment-hash')
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.error).toContain('does not match this post')
+    })
+  })
+
+  describe('Post Not Found', () => {
+    it('should return 404 when post does not exist', async () => {
+      mockL402Success()
+      mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'nonexistent-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('Post not found')
+    })
+  })
+
+  describe('State Validation', () => {
+    it('should return 409 when post is deleted', async () => {
+      mockL402Success()
+      mockPostData({ deleted_at: '2026-03-04T16:00:00Z' })
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('deleted')
+    })
+
+    it('should return 409 when fix is already approved', async () => {
+      mockL402Success()
+      mockPostData({ fixed: true })
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already been approved')
+    })
+
+    it('should return 409 when no fix is under review', async () => {
+      mockL402Success()
+      mockPostData({ under_review: false })
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('No fix is currently submitted')
+    })
+  })
+
+  describe('Successful Rejection', () => {
+    it('should reject fix and reopen post', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.post_id).toBe('test-post-id')
+      expect(data.message).toContain('open for new submissions')
+    })
+
+    it('should include rejection reason when provided', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true, { reason: 'The fix does not address the issue' })
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reason).toBe('The fix does not address the issue')
+    })
+
+    it('should work without a request body (reason is optional)', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const { POST } = await import('@/app/api/posts/[id]/reject/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reason).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `POST /api/posts/{id}/approve` — poster agents approve submitted fixes using their original L402 token. Auto-pays fixer reward via Lightning if a `payout_invoice` or Lightning address was provided.
- Adds `POST /api/posts/{id}/reject` — poster agents reject submitted fixes, clearing fix data and reopening the post. Accepts optional `{ "reason": "..." }` body.
- Updates API docs (`GET /api/posts`) to list the new endpoints.
- 24 unit tests covering authentication, authorization, state conflicts (409s), and payout success/failure.

## Context
Closes the loop on the L402 agent lifecycle: agents can now create posts, submit fixes, poll status, **and** approve/reject fixes — all without a web UI login.

## Test plan
- [x] 12 approve endpoint tests pass (auth, authz, 404, 409 states, payout w/ and w/o invoice)
- [x] 12 reject endpoint tests pass (auth, authz, 404, 409 states, with/without reason)
- [x] Existing post-status and fix-status tests still pass
- [x] API docs test updated to expect new endpoints

Made with [Cursor](https://cursor.com)