### PR TITLE
fix: guard payout invoices against amount exceeding post reward

### DIFF
--- a/app/actions/post-actions.ts
+++ b/app/actions/post-actions.ts
@@ -166,6 +166,16 @@ export async function payAnonymousFixLightningAddressAction(
       return { success: false, error: "Invalid Lightning invoice format." }
     }
 
+    // Guard: reject invoices that exceed the post reward to prevent draining
+    const { extractInvoiceAmount } = await import("@/lib/lightning-validation")
+    const invoiceAmount = extractInvoiceAmount(invoiceToPay)
+    if (invoiceAmount !== null && invoiceAmount > post.reward) {
+      return {
+        success: false,
+        error: `Payout invoice amount (${invoiceAmount} sats) exceeds post reward (${post.reward} sats). Refusing to pay.`,
+      }
+    }
+
     // Pay the invoice
     const { payInvoice } = await import("@/lib/lightning")
     const paymentResult = await payInvoice(invoiceToPay)

--- a/app/api/posts/[id]/approve/route.ts
+++ b/app/api/posts/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyL402Token, parseL402Header } from '@/lib/l402'
 import { createServerSupabaseClient } from '@/lib/supabase'
+import { extractInvoiceAmount } from '@/lib/lightning-validation'
 
 export const dynamic = 'force-dynamic'
 
@@ -196,6 +197,15 @@ async function payFixer(
     }
 
     invoiceToPay = invoiceData.pr
+  }
+
+  // Guard: reject invoices that exceed the post reward to prevent draining
+  const invoiceAmount = extractInvoiceAmount(invoiceToPay)
+  if (invoiceAmount !== null && invoiceAmount > reward) {
+    return {
+      success: false,
+      error: `Payout invoice amount (${invoiceAmount} sats) exceeds post reward (${reward} sats). Refusing to pay.`,
+    }
   }
 
   const { payInvoice } = await import('@/lib/lightning')

--- a/tests/unit/approve-api.test.ts
+++ b/tests/unit/approve-api.test.ts
@@ -12,6 +12,10 @@ vi.mock('@/lib/lightning', () => ({
   payInvoice: vi.fn(),
 }))
 
+vi.mock('@/lib/lightning-validation', () => ({
+  extractInvoiceAmount: vi.fn().mockReturnValue(null),
+}))
+
 const mockSingle = vi.fn()
 const mockEq = vi.fn().mockReturnThis()
 const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
@@ -275,6 +279,24 @@ describe('POST /api/posts/[id]/approve - Poster Approves Fix', () => {
       expect(data.success).toBe(true)
       expect(data.reward_paid).toBe(false)
       expect(data.message).toContain('payout failed')
+    })
+
+    it('should refuse payout when invoice amount exceeds post reward', async () => {
+      mockL402Success()
+      mockPostData({ submitted_fix_payout_invoice: 'lnbc100000n1malicious', reward: 100 })
+
+      const validation = await import('@/lib/lightning-validation')
+      vi.mocked(validation.extractInvoiceAmount).mockReturnValue(100000)
+
+      const { POST } = await import('@/app/api/posts/[id]/approve/route')
+      const request = createMockRequest(true)
+      const response = await POST(request, { params: Promise.resolve({ id: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reward_paid).toBe(false)
+      expect(data.reward_error).toContain('exceeds post reward')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Adds an amount guard in the L402 approve endpoint and the web UI payout path that rejects payout invoices whose encoded amount exceeds the post reward.
- Prevents a malicious fixer from draining the Lightning node by submitting an inflated BOLT11 invoice.
- 1 new unit test verifying the overpayment is refused.

## Test plan
- [x] New test: invoice amount 100,000 sats on a 100-sat reward post is refused
- [x] All 13 approve endpoint tests pass
- [x] No lint errors

Made with [Cursor](https://cursor.com)