### PR TITLE
fix: raise fix submission anti-spam fee from 1 to 10 sats

### DIFF
--- a/app/api/fixes/route.ts
+++ b/app/api/fixes/route.ts
@@ -4,7 +4,7 @@ import { submitAnonymousFixForReviewAction } from '@/app/actions/post-actions'
 
 export const dynamic = 'force-dynamic'
 
-const API_ACCESS_FEE = 1 // 1 sat anti-spam fee for fix submissions
+const API_ACCESS_FEE = 10 // 10 sat anti-spam fee for fix submissions
 
 /**
  * POST /api/fixes - Submit a fix for a post via L402-protected API


### PR DESCRIPTION
## Summary
- Raises the L402 anti-spam fee for fix submissions from 1 sat to 10 sats.
- 1 sat was trivially cheap for griefing (submitting garbage fixes to block posts).

## Test plan
- [x] All fix-related tests pass (fee is mocked at the L402 layer)
- One-line change: `const API_ACCESS_FEE = 10`

Made with [Cursor](https://cursor.com)