### PR TITLE
fix: accept amount-less BOLT11 Lightning invoices

### DIFF
--- a/lib/lightning-validation.ts
+++ b/lib/lightning-validation.ts
@@ -80,8 +80,9 @@ export function decodeLightningInvoice(invoice: string): DecodedInvoice {
     // Find the separator '1' - the LAST '1' in the invoice is the separator
     // because bech32 charset (used for the data part) doesn't include '1'
     // The amount portion can contain '1' (e.g., lnbc100u1...), so we use lastIndexOf
+    // When separatorIndex === prefix.length, the amount part is empty (valid any-amount invoice)
     const separatorIndex = trimmed.lastIndexOf('1')
-    if (separatorIndex === -1 || separatorIndex <= prefix.length) return result
+    if (separatorIndex === -1 || separatorIndex < prefix.length) return result
 
     // Extract amount string (between prefix and '1')
     const amountPart = trimmed.substring(prefix.length, separatorIndex)


### PR DESCRIPTION
## Summary
- Fixes a bug where valid any-amount (amount-less) BOLT11 invoices like `lnbc1...` were rejected by `decodeLightningInvoice`
- The bech32 separator `1` check used `<=` instead of `<`, causing invoices with no amount part (separator at exactly `prefix.length`) to be incorrectly treated as invalid
- This blocked anonymous fixers from withdrawing rewards using no-amount invoices

## Root Cause
In `lib/lightning-validation.ts` line 84, the condition `separatorIndex <= prefix.length` rejects invoices where the separator is at position 4 (right after `lnbc`). For amount-less invoices like `lnbc1p5e50n2...`, `separatorIndex` (4) equals `prefix.length` (4), so `4 <= 4` is `true` → invoice incorrectly rejected.

## Fix
Changed `<=` to `<`. When `separatorIndex === prefix.length`, the amount part is empty — a valid any-amount BOLT11 invoice. `parseInvoiceAmount('')` already correctly returns `null` for this case.

## Test plan
- [x] Verified the user's specific invoice `lnbc1p5e50n2...` now decodes as valid with `amount: null`
- [x] Verified invoices with amounts (`lnbc10u1...`, `lnbc100n1...`) still decode correctly
- [x] Confirmed `1` is not in the bech32 charset (so `lastIndexOf('1')` always finds the separator)

Made with [Cursor](https://cursor.com)