### PR TITLE
feat: fixer claim endpoint for reward payout retries

### DIFF
--- a/app/api/fixes/[postId]/claim/route.ts
+++ b/app/api/fixes/[postId]/claim/route.ts
@@ -1,0 +1,255 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyL402Token, parseL402Header } from '@/lib/l402'
+import { createServerSupabaseClient } from '@/lib/supabase'
+import { extractInvoiceAmount } from '@/lib/lightning-validation'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/fixes/[postId]/claim - Fixer claims reward with a new payout invoice
+ *
+ * After a fix is approved, the fixer can provide a new BOLT11 invoice or Lightning
+ * address to claim their reward. Useful when the initial payout failed (routing,
+ * expired invoice, etc.) or no payout_invoice was provided at submission time.
+ *
+ * Authentication: The L402 token's payment_hash must match the post's
+ * submitted_fix_payment_hash, proving the caller is the fixer.
+ *
+ * Request body:
+ * { "payout_invoice": "lnbc..." or "user@domain.com" }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const { postId } = await params
+
+  try {
+    const authHeader = request.headers.get('Authorization')
+
+    if (!authHeader) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token required. Use the same token from your POST /api/fixes payment.' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const l402Token = parseL402Header(authHeader)
+    if (!l402Token) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'Invalid Authorization header format. Expected: L402 <macaroon>:<preimage>' },
+          { status: 401 }
+        )
+      )
+    }
+
+    const verification = await verifyL402Token(l402Token, { skipExpiry: true })
+    if (!verification.success) {
+      return corsResponse(
+        NextResponse.json(
+          { error: `L402 verification failed: ${verification.error}` },
+          { status: 401 }
+        )
+      )
+    }
+
+    let body: { payout_invoice?: string }
+    try {
+      body = await request.json()
+    } catch {
+      return corsResponse(
+        NextResponse.json({ error: 'Invalid request body. Expected JSON with payout_invoice.' }, { status: 400 })
+      )
+    }
+
+    if (!body.payout_invoice || typeof body.payout_invoice !== 'string') {
+      return corsResponse(
+        NextResponse.json({ error: 'payout_invoice is required (BOLT11 invoice or Lightning address).' }, { status: 400 })
+      )
+    }
+
+    const supabase = createServerSupabaseClient()
+
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select(`
+        id, reward, fixed, deleted_at,
+        submitted_fix_payment_hash,
+        anonymous_reward_paid_at, anonymous_reward_payment_hash
+      `)
+      .eq('id', postId)
+      .single()
+
+    if (postError || !post) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post not found' }, { status: 404 })
+      )
+    }
+
+    if (post.submitted_fix_payment_hash !== verification.paymentHash) {
+      return corsResponse(
+        NextResponse.json(
+          { error: 'L402 token does not match a fix submission on this post.' },
+          { status: 403 }
+        )
+      )
+    }
+
+    if (post.deleted_at) {
+      return corsResponse(
+        NextResponse.json({ error: 'Post has been deleted' }, { status: 409 })
+      )
+    }
+
+    if (!post.fixed) {
+      return corsResponse(
+        NextResponse.json({ error: 'Fix has not been approved yet. Wait for the poster to approve.' }, { status: 409 })
+      )
+    }
+
+    if (post.anonymous_reward_paid_at) {
+      return corsResponse(
+        NextResponse.json({
+          error: 'Reward has already been paid.',
+          paid_at: post.anonymous_reward_paid_at,
+          payment_hash: post.anonymous_reward_payment_hash,
+        }, { status: 409 })
+      )
+    }
+
+    if (post.reward <= 0) {
+      return corsResponse(
+        NextResponse.json({ error: 'This post has no reward to claim.' }, { status: 409 })
+      )
+    }
+
+    // Update the stored payout invoice
+    await supabase
+      .from('posts')
+      .update({ submitted_fix_payout_invoice: body.payout_invoice })
+      .eq('id', postId)
+
+    // Attempt payment
+    const payoutResult = await payFixer(postId, body.payout_invoice, post.reward, supabase)
+
+    if (payoutResult.success) {
+      return corsResponse(
+        NextResponse.json({
+          success: true,
+          post_id: postId,
+          reward_paid: true,
+          reward_amount: post.reward,
+          payment_hash: payoutResult.paymentHash,
+          message: `Reward of ${post.reward} sats paid successfully.`,
+        })
+      )
+    }
+
+    return corsResponse(
+      NextResponse.json({
+        success: false,
+        post_id: postId,
+        reward_paid: false,
+        error: payoutResult.error,
+        message: 'Payment failed. You can retry with a different invoice.',
+      }, { status: 502 })
+    )
+  } catch (error) {
+    console.error('Error in POST /api/fixes/[postId]/claim:', error)
+    return corsResponse(
+      NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    )
+  }
+}
+
+async function payFixer(
+  postId: string,
+  payoutTarget: string,
+  reward: number,
+  supabase: ReturnType<typeof createServerSupabaseClient>,
+): Promise<{ success: boolean; paymentHash?: string; error?: string }> {
+  const trimmed = payoutTarget.trim().toLowerCase()
+  let invoiceToPay = trimmed
+
+  if (trimmed.includes('@') && trimmed.includes('.')) {
+    const [user, domain] = trimmed.split('@')
+    const lookupUrl = `https://${domain}/.well-known/lnurlp/${user}`
+
+    const lookupResponse = await fetch(lookupUrl)
+    if (!lookupResponse.ok) {
+      return { success: false, error: 'Failed to lookup Lightning address' }
+    }
+
+    const lookupData = await lookupResponse.json()
+    if (!lookupData.callback) {
+      return { success: false, error: 'Invalid Lightning address response' }
+    }
+
+    const callbackUrl = new URL(lookupData.callback)
+    callbackUrl.searchParams.set('amount', (reward * 1000).toString())
+
+    const invoiceResponse = await fetch(callbackUrl.toString())
+    if (!invoiceResponse.ok) {
+      return { success: false, error: 'Failed to generate invoice from Lightning address' }
+    }
+
+    const invoiceData = await invoiceResponse.json()
+    if (!invoiceData.pr) {
+      return { success: false, error: 'Invalid invoice response from Lightning address' }
+    }
+
+    invoiceToPay = invoiceData.pr
+  }
+
+  const invoiceAmount = extractInvoiceAmount(invoiceToPay)
+  if (invoiceAmount !== null && invoiceAmount > reward) {
+    return {
+      success: false,
+      error: `Invoice amount (${invoiceAmount} sats) exceeds reward (${reward} sats). Refusing to pay.`,
+    }
+  }
+
+  const { payInvoice } = await import('@/lib/lightning')
+  const paymentResult = await payInvoice(invoiceToPay)
+
+  if (!paymentResult.success) {
+    return { success: false, error: 'Lightning payment failed' }
+  }
+
+  const now = new Date().toISOString()
+  await supabase
+    .from('posts')
+    .update({
+      anonymous_reward_paid_at: now,
+      anonymous_reward_payment_hash: paymentResult.paymentHash || paymentResult.paymentPreimage,
+    })
+    .eq('id', postId)
+
+  return { success: true, paymentHash: paymentResult.paymentHash || paymentResult.paymentPreimage }
+}
+
+function corsResponse(response: NextResponse): NextResponse {
+  if (process.env.NODE_ENV === 'development') {
+    response.headers.set('Access-Control-Allow-Origin', '*')
+    response.headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  }
+  return response
+}
+
+export async function OPTIONS() {
+  if (process.env.NODE_ENV === 'development') {
+    return new NextResponse(null, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    })
+  }
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/fixes/route.ts
+++ b/app/api/fixes/route.ts
@@ -204,6 +204,7 @@ export async function GET() {
       endpoints: {
         'POST /api/fixes': 'Submit a fix for a post (requires L402 payment)',
         'GET /api/fixes/{post_id}': 'Poll fix status (reuse your L402 token, no extra payment)',
+        'POST /api/fixes/{post_id}/claim': 'Claim reward with a new invoice after approval (reuse your L402 token)',
       },
       l402_info: {
         fee: `${API_ACCESS_FEE} sat (anti-spam)`,
@@ -218,6 +219,7 @@ export async function GET() {
       },
       notes: '*At least one of proof_text or proof_image_url must be provided.',
       status_polling: 'After submitting, reuse your L402 token (Authorization header) to GET /api/fixes/{post_id} for status updates. No additional payment required.',
+      reward_claim: 'If your fix is approved but payout failed (or you did not provide a payout_invoice), POST /api/fixes/{post_id}/claim with { "payout_invoice": "lnbc..." } to retry. You can call this as many times as needed with different invoices.',
     })
   )
 }

--- a/tests/unit/claim-reward-api.test.ts
+++ b/tests/unit/claim-reward-api.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/l402', () => ({
+  verifyL402Token: vi.fn(),
+  parseL402Header: vi.fn(),
+}))
+
+vi.mock('@/lib/lightning', () => ({
+  createInvoice: vi.fn(),
+  checkInvoice: vi.fn(),
+  payInvoice: vi.fn(),
+}))
+
+vi.mock('@/lib/lightning-validation', () => ({
+  extractInvoiceAmount: vi.fn().mockReturnValue(null),
+}))
+
+const mockSingle = vi.fn()
+const mockEq = vi.fn().mockReturnThis()
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) })
+mockEq.mockImplementation(() => ({
+  eq: mockEq,
+  single: mockSingle,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  createServerSupabaseClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: mockSelect,
+      update: mockUpdate,
+    })),
+  })),
+}))
+
+import * as l402 from '@/lib/l402'
+
+const MOCK_FIXER_HASH = 'fixer-payment-hash-abc123def456'
+
+function createMockRequest(withAuth = true, body?: Record<string, unknown>) {
+  const headers = new Headers()
+  if (withAuth) {
+    headers.set('Authorization', 'L402 mock-macaroon:mock-preimage')
+  }
+  const init: RequestInit = { method: 'POST', headers }
+  if (body) {
+    headers.set('Content-Type', 'application/json')
+    init.body = JSON.stringify(body)
+  }
+  return new NextRequest('http://localhost:3000/api/fixes/test-post-id/claim', init)
+}
+
+function mockL402Success(paymentHash = MOCK_FIXER_HASH) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: true,
+    paymentHash,
+  })
+}
+
+function mockL402Failure(error: string) {
+  vi.mocked(l402.parseL402Header).mockReturnValue({
+    macaroon: 'mock-macaroon',
+    preimage: 'mock-preimage',
+  })
+  vi.mocked(l402.verifyL402Token).mockResolvedValue({
+    success: false,
+    error,
+  })
+}
+
+function mockPostData(overrides: Record<string, unknown> = {}) {
+  mockSingle.mockResolvedValue({
+    data: {
+      id: 'test-post-id',
+      reward: 100,
+      fixed: true,
+      deleted_at: null,
+      submitted_fix_payment_hash: MOCK_FIXER_HASH,
+      anonymous_reward_paid_at: null,
+      anonymous_reward_payment_hash: null,
+      ...overrides,
+    },
+    error: null,
+  })
+}
+
+describe('POST /api/fixes/[postId]/claim - Fixer Claims Reward', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('Authentication', () => {
+    it('should return 401 when no Authorization header is provided', async () => {
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(false, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toContain('L402 token required')
+    })
+
+    it('should return 401 when L402 header is malformed', async () => {
+      vi.mocked(l402.parseL402Header).mockReturnValue(null)
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('should return 401 when L402 verification fails', async () => {
+      mockL402Failure('Invalid preimage')
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('should call verifyL402Token with skipExpiry: true', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const lightning = await import('@/lib/lightning')
+      vi.mocked(lightning.payInvoice).mockResolvedValue({ success: true, paymentHash: 'h' } as any)
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(l402.verifyL402Token).toHaveBeenCalledWith(expect.any(Object), { skipExpiry: true })
+    })
+  })
+
+  describe('Validation', () => {
+    it('should return 400 when no payout_invoice is provided', async () => {
+      mockL402Success()
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, {})
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toContain('payout_invoice is required')
+    })
+
+    it('should return 400 when request body is not valid JSON', async () => {
+      mockL402Success()
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const headers = new Headers()
+      headers.set('Authorization', 'L402 mock-macaroon:mock-preimage')
+      const request = new NextRequest('http://localhost:3000/api/fixes/test-post-id/claim', {
+        method: 'POST',
+        headers,
+      })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('Authorization', () => {
+    it('should return 403 when payment hash does not match fixer', async () => {
+      mockL402Success('wrong-fixer-hash')
+      mockPostData()
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.error).toContain('does not match')
+    })
+  })
+
+  describe('State Validation', () => {
+    it('should return 404 when post does not exist', async () => {
+      mockL402Success()
+      mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'nonexistent' }) })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('should return 409 when post is deleted', async () => {
+      mockL402Success()
+      mockPostData({ deleted_at: '2026-03-04T00:00:00Z' })
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(response.status).toBe(409)
+    })
+
+    it('should return 409 when fix has not been approved yet', async () => {
+      mockL402Success()
+      mockPostData({ fixed: false })
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('not been approved yet')
+    })
+
+    it('should return 409 when reward has already been paid', async () => {
+      mockL402Success()
+      mockPostData({
+        anonymous_reward_paid_at: '2026-03-04T12:00:00Z',
+        anonymous_reward_payment_hash: 'already-paid-hash',
+      })
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already been paid')
+      expect(data.paid_at).toBe('2026-03-04T12:00:00Z')
+    })
+
+    it('should return 409 when post has no reward', async () => {
+      mockL402Success()
+      mockPostData({ reward: 0 })
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+
+      expect(response.status).toBe(409)
+      expect((await response.json()).error).toContain('no reward')
+    })
+  })
+
+  describe('Successful Claim', () => {
+    it('should pay reward and return success', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const lightning = await import('@/lib/lightning')
+      vi.mocked(lightning.payInvoice).mockResolvedValue({
+        success: true,
+        paymentHash: 'reward-paid-hash',
+      } as any)
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.reward_paid).toBe(true)
+      expect(data.reward_amount).toBe(100)
+      expect(data.payment_hash).toBe('reward-paid-hash')
+    })
+
+    it('should return 502 when payment fails (retryable)', async () => {
+      mockL402Success()
+      mockPostData()
+
+      const lightning = await import('@/lib/lightning')
+      vi.mocked(lightning.payInvoice).mockResolvedValue({
+        success: false,
+        error: 'No route',
+      } as any)
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc100n1test' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(502)
+      expect(data.success).toBe(false)
+      expect(data.reward_paid).toBe(false)
+      expect(data.message).toContain('retry')
+    })
+
+    it('should refuse invoice exceeding reward amount', async () => {
+      mockL402Success()
+      mockPostData({ reward: 100 })
+
+      const validation = await import('@/lib/lightning-validation')
+      vi.mocked(validation.extractInvoiceAmount).mockReturnValue(50000)
+
+      const { POST } = await import('@/app/api/fixes/[postId]/claim/route')
+      const request = createMockRequest(true, { payout_invoice: 'lnbc500000n1malicious' })
+      const response = await POST(request, { params: Promise.resolve({ postId: 'test-post-id' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(502)
+      expect(data.error).toContain('exceeds reward')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `POST /api/fixes/{postId}/claim` — fixer provides a new BOLT11 invoice or Lightning address to retry reward payout after approval.
- Handles the case where the initial payout fails (routing issues, expired invoice) or no payout_invoice was provided at fix submission time.
- Includes the same invoice amount guard to prevent overpayment.
- API docs updated with new endpoint and usage instructions.

## Test plan
- [x] 15 unit tests covering auth, validation, state conflicts, successful payment, failed payment (502 retryable), and amount guard
- [x] No lint errors

Made with [Cursor](https://cursor.com)