### PR TITLE
fix: hide app header/nav on docs page, force dark mode

### DIFF
--- a/app/docs/docs-chrome.tsx
+++ b/app/docs/docs-chrome.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function DocsChrome() {
+  useEffect(() => {
+    document.documentElement.classList.add('dark')
+    document.body.classList.add('docs-standalone')
+
+    return () => {
+      document.body.classList.remove('docs-standalone')
+    }
+  }, [])
+
+  return (
+    <style>{`
+      .docs-standalone header.fixed { display: none !important; }
+      .docs-standalone #bottom-nav { display: none !important; }
+      .docs-standalone main { padding-top: 0 !important; }
+    `}</style>
+  )
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { DocsChrome } from "./docs-chrome"
 
 export const metadata: Metadata = {
   title: "API Documentation | Ganamos",
@@ -23,5 +24,10 @@ export default function DocsLayout({
 }: {
   children: React.ReactNode
 }) {
-  return <>{children}</>
+  return (
+    <>
+      <DocsChrome />
+      {children}
+    </>
+  )
 }


### PR DESCRIPTION
## Summary

- The docs page at `docs.ganamos.earth` was rendering inside the main app layout, showing the white Ganamos header and bottom nav bar
- Add a `DocsChrome` client component that hides the app's `DesktopHeader` and `BottomNav`, removes layout padding, and forces dark mode when on `/docs` routes
- The docs page now renders standalone with only its own dark terminal-style header

## Test plan

- [ ] Verify `docs.ganamos.earth` loads without the white app header or bottom nav
- [ ] Verify the docs page shows in dark mode with its own header bar
- [ ] Verify other pages (dashboard, map, etc.) still show the normal app header


Made with [Cursor](https://cursor.com)