### PR TITLE
fix: keep app header on docs page

### DIFF
--- a/app/docs/docs-chrome.tsx
+++ b/app/docs/docs-chrome.tsx
@@ -5,18 +5,8 @@ import { useEffect } from 'react'
 export function DocsChrome() {
   useEffect(() => {
     document.documentElement.classList.add('dark')
-    document.body.classList.add('docs-standalone')
-
-    return () => {
-      document.body.classList.remove('docs-standalone')
-    }
+    localStorage.setItem('theme', 'dark')
   }, [])
 
-  return (
-    <style>{`
-      .docs-standalone header.fixed { display: none !important; }
-      .docs-standalone #bottom-nav { display: none !important; }
-      .docs-standalone main { padding-top: 0 !important; }
-    `}</style>
-  )
+  return null
 }


### PR DESCRIPTION
## Summary

- Previous commit incorrectly hid the app header on docs.ganamos.earth
- Users need the header to navigate to Map, Wallet, Profile, etc.
- Now only forces dark mode — header stays visible and functional

## Test plan

- [ ] Verify docs.ganamos.earth shows the dark Ganamos header with nav tabs
- [ ] Verify clicking Map, Wallet, etc. navigates correctly


Made with [Cursor](https://cursor.com)