### PR TITLE
fix: L402 replay protection for single-use endpoints

### DIFF
--- a/app/api/fixes/route.ts
+++ b/app/api/fixes/route.ts
@@ -79,6 +79,22 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Replay protection: reject if this payment hash was already used
+    const { createServerSupabaseClient } = await import('@/lib/supabase')
+    const replaySupabase = createServerSupabaseClient()
+    const { error: replayError } = await replaySupabase
+      .from('l402_used_tokens')
+      .insert({ payment_hash: verification.paymentHash!, endpoint: 'POST /api/fixes' })
+
+    if (replayError?.code === '23505') { // unique_violation
+      return corsResponse(
+        NextResponse.json(
+          { error: 'This L402 token has already been used to submit a fix. Pay for a new token to submit another fix.' },
+          { status: 409 }
+        )
+      )
+    }
+
     const body = await request.json()
     const { post_id, proof_text, proof_image_url, note, payout_invoice } = body
 
@@ -220,6 +236,7 @@ export async function GET() {
       notes: '*At least one of proof_text or proof_image_url must be provided.',
       status_polling: 'After submitting, reuse your L402 token (Authorization header) to GET /api/fixes/{post_id} for status updates. No additional payment required.',
       reward_claim: 'If your fix is approved but payout failed (or you did not provide a payout_invoice), POST /api/fixes/{post_id}/claim with { "payout_invoice": "lnbc..." } to retry. You can call this as many times as needed with different invoices.',
+      replay_protection: 'Each L402 token can only be used once to submit a fix. Attempting to reuse a token returns 409 Conflict.',
     })
   )
 }

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -129,6 +129,33 @@ export async function POST(request: NextRequest) {
       return mismatchErrorResponse
     }
 
+    // Replay protection: atomically record this payment hash as used
+    const { createServerSupabaseClient } = await import('@/lib/supabase')
+    const replaySupabase = createServerSupabaseClient()
+    const { error: replayError } = await replaySupabase
+      .from('l402_used_tokens')
+      .insert({ payment_hash: verification.paymentHash!, endpoint: 'POST /api/posts' })
+
+    if (replayError?.code === '23505') { // unique_violation (PRIMARY KEY conflict)
+      // Look up the existing post to return its ID
+      const { data: existingPost } = await replaySupabase
+        .from('posts')
+        .select('id')
+        .eq('funding_r_hash', verification.paymentHash!)
+        .maybeSingle()
+
+      const replayResponse = NextResponse.json(
+        { error: 'This L402 token has already been used to create a post. Pay for a new token to create another post.', existing_post_id: existingPost?.id || null },
+        { status: 409 }
+      )
+      if (process.env.NODE_ENV === 'development') {
+        replayResponse.headers.set('Access-Control-Allow-Origin', '*')
+        replayResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        replayResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+      }
+      return replayResponse
+    }
+
     // Create the post using existing logic
     const postResult = await createFundedAnonymousPostAction({
       description,
@@ -270,6 +297,7 @@ export async function GET(request: NextRequest) {
     },
     status_polling: 'After creating a post, reuse your L402 token (Authorization header) to GET /api/posts/{id} for status updates. No additional payment required — the token is a persistent bearer instrument.',
     fix_management: 'When a fix is submitted (status changes to under_review), use POST /api/posts/{id}/approve or POST /api/posts/{id}/reject to manage it. Approval triggers automatic reward payout if the fixer provided a payout_invoice.',
+    replay_protection: 'Each L402 token can only be used once to create a post. Attempting to reuse a token returns 409 Conflict with the existing post ID.',
   })
   
   // Add CORS headers for development only

--- a/supabase/migrations/20260305000001_l402_used_tokens.sql
+++ b/supabase/migrations/20260305000001_l402_used_tokens.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS l402_used_tokens (
+  payment_hash TEXT PRIMARY KEY,
+  endpoint TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/tests/unit/fixes-replay-api.test.ts
+++ b/tests/unit/fixes-replay-api.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/l402', () => ({
+  createL402Challenge: vi.fn(),
+  verifyL402Token: vi.fn(),
+  parseL402Header: vi.fn(),
+}))
+
+vi.mock('@/app/actions/post-actions', () => ({
+  submitAnonymousFixForReviewAction: vi.fn(),
+}))
+
+const mockInsert = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  createServerSupabaseClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === 'l402_used_tokens') {
+        return { insert: mockInsert }
+      }
+      return {}
+    }),
+  })),
+}))
+
+import * as l402 from '@/lib/l402'
+import * as postActions from '@/app/actions/post-actions'
+import { POST } from '@/app/api/fixes/route'
+
+function createMockRequest(body: any, authHeader?: string): NextRequest {
+  const headers = new Headers()
+  if (authHeader) {
+    headers.set('Authorization', authHeader)
+  }
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    headers,
+    method: 'POST',
+  } as any
+}
+
+describe('POST /api/fixes - Replay Protection', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.NODE_ENV = 'production'
+    mockInsert.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+    vi.restoreAllMocks()
+  })
+
+  it('should reject duplicate L402 token with 409 Conflict', async () => {
+    const mockToken = { macaroon: 'mock-mac', preimage: 'mock-pre' }
+    vi.mocked(l402.parseL402Header).mockReturnValue(mockToken as any)
+    vi.mocked(l402.verifyL402Token).mockResolvedValue({
+      success: true,
+      paymentHash: 'replay-hash-123',
+      macaroon: {} as any,
+    })
+
+    mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate key' } })
+
+    const body = { post_id: 'post-1', proof_text: 'I fixed it' }
+    const request = createMockRequest(body, 'L402 mock-mac:mock-pre')
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toContain('already been used')
+    expect(postActions.submitAnonymousFixForReviewAction).not.toHaveBeenCalled()
+  })
+
+  it('should allow first use of L402 token for fix submission', async () => {
+    const mockToken = { macaroon: 'mock-mac', preimage: 'mock-pre' }
+    vi.mocked(l402.parseL402Header).mockReturnValue(mockToken as any)
+    vi.mocked(l402.verifyL402Token).mockResolvedValue({
+      success: true,
+      paymentHash: 'new-hash-456',
+      macaroon: {} as any,
+    })
+    vi.mocked(postActions.submitAnonymousFixForReviewAction).mockResolvedValue({
+      success: true,
+    } as any)
+
+    mockInsert.mockResolvedValue({ error: null })
+
+    const body = { post_id: 'post-1', proof_text: 'I fixed it' }
+    const request = createMockRequest(body, 'L402 mock-mac:mock-pre')
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data.success).toBe(true)
+    expect(postActions.submitAnonymousFixForReviewAction).toHaveBeenCalled()
+  })
+
+  it('should record payment hash with correct endpoint', async () => {
+    const mockToken = { macaroon: 'mock-mac', preimage: 'mock-pre' }
+    vi.mocked(l402.parseL402Header).mockReturnValue(mockToken as any)
+    vi.mocked(l402.verifyL402Token).mockResolvedValue({
+      success: true,
+      paymentHash: 'hash-to-record',
+      macaroon: {} as any,
+    })
+    vi.mocked(postActions.submitAnonymousFixForReviewAction).mockResolvedValue({
+      success: true,
+    } as any)
+
+    mockInsert.mockResolvedValue({ error: null })
+
+    const body = { post_id: 'post-1', proof_text: 'I fixed it' }
+    const request = createMockRequest(body, 'L402 mock-mac:mock-pre')
+    await POST(request)
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      payment_hash: 'hash-to-record',
+      endpoint: 'POST /api/fixes',
+    })
+  })
+
+  it('should still validate request body after replay check passes', async () => {
+    const mockToken = { macaroon: 'mock-mac', preimage: 'mock-pre' }
+    vi.mocked(l402.parseL402Header).mockReturnValue(mockToken as any)
+    vi.mocked(l402.verifyL402Token).mockResolvedValue({
+      success: true,
+      paymentHash: 'hash-789',
+      macaroon: {} as any,
+    })
+
+    mockInsert.mockResolvedValue({ error: null })
+
+    const body = { post_id: 'post-1' } // missing proof_text and proof_image_url
+    const request = createMockRequest(body, 'L402 mock-mac:mock-pre')
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('proof_text or proof_image_url')
+  })
+
+  it('should reject replay before validating request body', async () => {
+    const mockToken = { macaroon: 'mock-mac', preimage: 'mock-pre' }
+    vi.mocked(l402.parseL402Header).mockReturnValue(mockToken as any)
+    vi.mocked(l402.verifyL402Token).mockResolvedValue({
+      success: true,
+      paymentHash: 'replayed-hash',
+      macaroon: {} as any,
+    })
+
+    mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate key' } })
+
+    const body = {} // intentionally invalid body
+    const request = createMockRequest(body, 'L402 mock-mac:mock-pre')
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toContain('already been used')
+  })
+})

--- a/tests/unit/posts-api.test.ts
+++ b/tests/unit/posts-api.test.ts
@@ -45,6 +45,31 @@ vi.mock('@/app/actions/post-actions', () => ({
   createFundedAnonymousPostAction: vi.fn(),
 }))
 
+const mockInsert = vi.fn()
+const mockSupabaseSelect = vi.fn()
+const mockSupabaseEq = vi.fn()
+const mockSupabaseMaybeSingle = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  createServerSupabaseClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === 'l402_used_tokens') {
+        return { insert: mockInsert }
+      }
+      if (table === 'posts') {
+        return {
+          select: mockSupabaseSelect.mockReturnValue({
+            eq: mockSupabaseEq.mockReturnValue({
+              maybeSingle: mockSupabaseMaybeSingle,
+            }),
+          }),
+        }
+      }
+      return {}
+    }),
+  })),
+}))
+
 // Import mocked functions for assertions
 import * as l402 from '@/lib/l402'
 import * as lightning from '@/lib/lightning'
@@ -74,7 +99,8 @@ describe('POST /api/posts Integration Tests', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.NODE_ENV = 'production' // Default to production for testing
+    process.env.NODE_ENV = 'production'
+    mockInsert.mockResolvedValue({ error: null })
   })
 
   afterEach(() => {
@@ -902,6 +928,115 @@ describe('POST /api/posts Integration Tests', () => {
       // Should proceed without amount verification when caveat is missing
       expect(response.status).toBe(201)
       expect(data.success).toBe(true)
+    })
+  })
+
+  describe('Replay Protection', () => {
+    it('should reject duplicate L402 token with 409 Conflict', async () => {
+      const mockPostData = createMockPostData({ reward: 1000 })
+      const mockToken = createMockL402Token()
+      const paymentHash = 'payment-hash-123'
+      const mockMacaroon = createMockMacaroon({ amount: 1010 })
+      
+      mockL402TokenParsingSuccess(l402, mockToken)
+      mockL402VerificationSuccess(l402, paymentHash, mockMacaroon)
+      
+      // Simulate unique_violation from the l402_used_tokens table
+      mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate key' } })
+      mockSupabaseMaybeSingle.mockResolvedValue({ data: { id: 'existing-post-id' }, error: null })
+
+      const authHeader = createL402AuthHeader(mockToken)
+      const request = createMockRequest(mockPostData, authHeader)
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already been used')
+      expect(data.existing_post_id).toBe('existing-post-id')
+      expect(postActions.createFundedAnonymousPostAction).not.toHaveBeenCalled()
+    })
+
+    it('should allow first use of L402 token', async () => {
+      const mockPostData = createMockPostData({ reward: 1000 })
+      const mockToken = createMockL402Token()
+      const paymentHash = 'payment-hash-123'
+      const mockMacaroon = createMockMacaroon({ amount: 1010 })
+      
+      mockL402TokenParsingSuccess(l402, mockToken)
+      mockL402VerificationSuccess(l402, paymentHash, mockMacaroon)
+      mockPostCreationSuccess(postActions, 'new-post-id')
+      mockInsert.mockResolvedValue({ error: null })
+
+      const authHeader = createL402AuthHeader(mockToken)
+      const request = createMockRequest(mockPostData, authHeader)
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(201)
+      expect(data.success).toBe(true)
+      expect(data.post_id).toBe('new-post-id')
+    })
+
+    it('should include CORS headers in replay rejection in development mode', async () => {
+      process.env.NODE_ENV = 'development'
+      
+      const mockPostData = createMockPostData({ reward: 1000 })
+      const mockToken = createMockL402Token()
+      const paymentHash = 'payment-hash-123'
+      const mockMacaroon = createMockMacaroon({ amount: 1010 })
+      
+      mockL402TokenParsingSuccess(l402, mockToken)
+      mockL402VerificationSuccess(l402, paymentHash, mockMacaroon)
+      mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate key' } })
+      mockSupabaseMaybeSingle.mockResolvedValue({ data: null, error: null })
+
+      const authHeader = createL402AuthHeader(mockToken)
+      const request = createMockRequest(mockPostData, authHeader)
+      const response = await POST(request)
+
+      expect(response.status).toBe(409)
+      expectCorsHeadersPresent(response)
+    })
+
+    it('should return null existing_post_id when post lookup fails', async () => {
+      const mockPostData = createMockPostData({ reward: 1000 })
+      const mockToken = createMockL402Token()
+      const paymentHash = 'payment-hash-123'
+      const mockMacaroon = createMockMacaroon({ amount: 1010 })
+      
+      mockL402TokenParsingSuccess(l402, mockToken)
+      mockL402VerificationSuccess(l402, paymentHash, mockMacaroon)
+      mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate key' } })
+      mockSupabaseMaybeSingle.mockResolvedValue({ data: null, error: null })
+
+      const authHeader = createL402AuthHeader(mockToken)
+      const request = createMockRequest(mockPostData, authHeader)
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.existing_post_id).toBeNull()
+    })
+
+    it('should record payment hash with correct endpoint', async () => {
+      const mockPostData = createMockPostData({ reward: 1000 })
+      const mockToken = createMockL402Token()
+      const paymentHash = 'unique-hash-456'
+      const mockMacaroon = createMockMacaroon({ amount: 1010 })
+      
+      mockL402TokenParsingSuccess(l402, mockToken)
+      mockL402VerificationSuccess(l402, paymentHash, mockMacaroon)
+      mockPostCreationSuccess(postActions, 'post-123')
+      mockInsert.mockResolvedValue({ error: null })
+
+      const authHeader = createL402AuthHeader(mockToken)
+      const request = createMockRequest(mockPostData, authHeader)
+      await POST(request)
+
+      expect(mockInsert).toHaveBeenCalledWith({
+        payment_hash: paymentHash,
+        endpoint: 'POST /api/posts',
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- **Fixes the L402 replay bug** where a single payment token could be reused to create unlimited posts or submit unlimited fixes
- Adds a `l402_used_tokens` database table with `payment_hash` as PRIMARY KEY for atomic duplicate detection
- `POST /api/posts`: Records payment hash on use, returns 409 with `existing_post_id` if replayed
- `POST /api/fixes`: Records payment hash on use, returns 409 if replayed
- **Audited all 7 L402 endpoints** — the other 5 (GET status polling, approve, reject, claim) are already safe via read-only semantics or state guards (e.g., "already approved" 409)

## Test plan

- [x] 5 new replay protection tests for POST /api/posts (duplicate rejection, first-use allowed, CORS headers, null post lookup, correct endpoint recording)
- [x] 5 new replay protection tests for POST /api/fixes (duplicate rejection, first-use allowed, correct endpoint recording, validation order, rejection before body validation)
- [x] All 143 L402 endpoint tests pass
- [ ] Apply `20260305000001_l402_used_tokens.sql` migration to production Supabase
- [ ] E2E test: create post, verify replay returns 409 with existing_post_id


Made with [Cursor](https://cursor.com)