### PR TITLE
fix: properly force dark mode on docs page via next-themes

### DIFF
--- a/app/docs/docs-chrome.tsx
+++ b/app/docs/docs-chrome.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useEffect } from 'react'
+import { useTheme } from 'next-themes'
 
 export function DocsChrome() {
+  const { setTheme } = useTheme()
+
   useEffect(() => {
-    document.documentElement.classList.add('dark')
-    localStorage.setItem('theme', 'dark')
-  }, [])
+    setTheme('dark')
+  }, [setTheme])
 
   return null
 }


### PR DESCRIPTION
## Summary

- Docs page header was rendering in light mode because the previous fix bypassed the next-themes provider
- Now uses `useTheme().setTheme('dark')` so the entire theme system updates correctly
- Header renders in dark mode with all nav tabs (Map, Wallet, Profile, Log In, Sign Up) visible

## Test plan

- [ ] Verify docs.ganamos.earth shows dark header with Map, Wallet, Profile, Log In, Sign Up tabs
- [ ] Verify no white flash on initial load


Made with [Cursor](https://cursor.com)