### PR TITLE
fix: docs sub-page routing and layout tweaks

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -238,22 +238,34 @@ export default function DocsPage() {
         {/* Main content */}
         <div ref={mainRef} className="flex-1 min-w-0 px-4 sm:px-6 lg:px-8 pb-16">
 
+          {/* Tagline */}
+          <div className="py-3 text-[10px] text-neutral-600 tracking-wide leading-relaxed">
+            Ganamos is a Bitcoin-powered job marketplace for AI agents. Post tasks, fund them with Lightning micropayments, and humans (or other agents) fix them and earn sats. No account required — L402 tokens are your identity.
+          </div>
+
           {/* QUICK START */}
           <SectionHeader id="quickstart" label="Quick Start" dotColor="green" />
           <div className="py-4 space-y-1 border-b border-[#111]">
             <InfoRow label="Base URL" value="https://www.ganamos.earth/api" />
             <InfoRow label="Protocol" value="L402 (HTTP 402 + Lightning Network)" />
             <InfoRow label="Format" value="JSON" />
-            <InfoRow label="Status" value="Operational" />
             <InfoRowLink label="OpenAPI" href="https://www.ganamos.earth/openapi.json" text="openapi.json" />
             <InfoRowLink label="MCP Card" href="https://www.ganamos.earth/.well-known/mcp.json" text=".well-known/mcp.json" />
           </div>
-          <div className="py-3 text-[10px] text-neutral-600 tracking-wide leading-relaxed">
-            Ganamos is a Bitcoin-powered job marketplace for AI agents. Post tasks, fund them with Lightning micropayments, and humans (or other agents) fix them and earn sats. No account required — L402 tokens are your identity.
-          </div>
+
+          {/* Live Demo CTA */}
+          <a href="/docs/demo" className="block mt-3 border border-amber-400/15 bg-amber-400/[0.03] p-4 hover:bg-amber-400/[0.05] hover:border-amber-400/25 transition-colors group">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-[10px] tracking-[0.15em] text-amber-400/80 mb-1">TRY IT LIVE</div>
+                <div className="text-[10px] text-neutral-500">Post a real job to Ganamos with Lightning — right from this page. No setup needed.</div>
+              </div>
+              <span className="text-amber-400/60 group-hover:text-amber-400 text-sm transition-colors">→</span>
+            </div>
+          </a>
 
           {/* 30-SECOND QUICKSTART */}
-          <div className="border border-emerald-500/10 bg-emerald-500/[0.02] p-4 mt-2">
+          <div className="border border-emerald-500/10 bg-emerald-500/[0.02] p-4 mt-3">
             <div className="text-[10px] tracking-[0.15em] text-emerald-400/80 mb-3">POST YOUR FIRST JOB IN 30 SECONDS</div>
             <StepLabel n={1} label="Send a POST (you'll get a Lightning invoice back)" />
             <CodeBlock>{`curl -X POST https://www.ganamos.earth/api/posts \\
@@ -277,17 +289,6 @@ export default function DocsPage() {
               Save the L402 token — it&apos;s your permanent identity for this job. Reuse it to poll status, approve fixes, and reject submissions.
             </div>
           </div>
-
-          {/* Live Demo CTA */}
-          <a href="/docs/demo" className="block mt-3 border border-amber-400/15 bg-amber-400/[0.03] p-4 hover:bg-amber-400/[0.05] hover:border-amber-400/25 transition-colors group">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-[10px] tracking-[0.15em] text-amber-400/80 mb-1">TRY IT LIVE</div>
-                <div className="text-[10px] text-neutral-500">Post a real job to Ganamos with Lightning — right from this page. No setup needed.</div>
-              </div>
-              <span className="text-amber-400/60 group-hover:text-amber-400 text-sm transition-colors">→</span>
-            </div>
-          </a>
 
           {/* JOB LIFECYCLE */}
           <SectionHeader id="lifecycle" label="Job Lifecycle" dotColor="cyan" />

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,7 +62,11 @@ export async function middleware(req: NextRequest) {
     if (path.startsWith("/openapi.json") || path.startsWith("/.well-known") || path.startsWith("/_next")) {
       return res
     }
-    // Route known sub-pages under /docs
+    // If path already starts with /docs, use as-is (avoids /docs/docs/demo double-prefix)
+    if (path.startsWith("/docs")) {
+      return NextResponse.rewrite(new URL(path, req.url))
+    }
+    // Otherwise prepend /docs (e.g. /demo → /docs/demo)
     return NextResponse.rewrite(new URL(`/docs${path}`, req.url))
   }
 


### PR DESCRIPTION
## Summary

- Fix 404 on `docs.ganamos.earth/docs/demo` — middleware was double-prefixing paths that already start with `/docs`
- Move tagline paragraph above the Quick Start header
- Remove redundant "Status: Operational" row (already shown by the green dot in the header bar)
- Move "Try it Live" CTA above the 30-second quickstart code block

## Test plan

- [ ] Verify `docs.ganamos.earth/docs/demo` loads the demo page (no more 404)
- [ ] Verify `docs.ganamos.earth/demo` also loads correctly
- [ ] Verify docs page layout order: tagline → Quick Start → Try it Live → 30-second quickstart


Made with [Cursor](https://cursor.com)