### PR TITLE
fix: force dark mode on docs.ganamos.earth before first paint

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,8 +66,9 @@ export default function RootLayout({
             __html: `
               (function() {
                 try {
+                  var isDocs = window.location.hostname === 'docs.ganamos.earth';
                   var theme = localStorage.getItem('theme');
-                  if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                  if (isDocs || theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
                     document.documentElement.classList.add('dark');
                   } else {
                     document.documentElement.classList.remove('dark');


### PR DESCRIPTION
## Summary

- The `useTheme('dark')` approach in `DocsChrome` runs after hydration, causing the header to render in light mode first (white flash)
- Fix: add a `docs.ganamos.earth` hostname check to the existing blocking `<script>` in `app/layout.tsx` that runs synchronously before the first paint
- This is a 1-line change to the theme FOUC prevention script — guaranteed dark mode before anything renders

## Test plan

- [ ] Verify `docs.ganamos.earth` loads with dark header immediately (no white flash)
- [ ] Verify `www.ganamos.earth` still respects user's theme preference
- [ ] Verify header shows Map, Wallet, Profile, Log In, Sign Up in dark mode


Made with [Cursor](https://cursor.com)