### PR TITLE
fix: prevent light mode forcing on docs.ganamos.earth

### DIFF
--- a/components/conditional-theme-provider.tsx
+++ b/components/conditional-theme-provider.tsx
@@ -10,7 +10,22 @@ export function ConditionalThemeProvider({
 }: { children: React.ReactNode } & ThemeProviderProps) {
   const pathname = usePathname()
 
-  // Force light mode on home, login, and public job posting pages
+  // On docs.ganamos.earth, middleware rewrites / → /docs on the server, but
+  // usePathname() returns "/" (browser URL) on the client after hydration.
+  // Without this hostname check, pathname === "/" triggers forcedTheme="light",
+  // overriding the dark theme the docs page needs.
+  const isDocsDomain = typeof window !== 'undefined' &&
+    window.location.hostname === 'docs.ganamos.earth'
+  const isDocsPage = pathname === "/docs" || pathname.startsWith("/docs/")
+
+  if (isDocsPage || isDocsDomain) {
+    return (
+      <NextThemesProvider {...props} forcedTheme="dark">
+        {children}
+      </NextThemesProvider>
+    )
+  }
+
   const isLightModePage = pathname === "/" || pathname.startsWith("/auth") || pathname === "/new"
 
   if (isLightModePage) {
@@ -21,6 +36,5 @@ export function ConditionalThemeProvider({
     )
   }
 
-  // Use default theme provider with dark mode default for all other pages
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }


### PR DESCRIPTION
## Summary

- **Root cause**: On `docs.ganamos.earth`, middleware rewrites `/` → `/docs` on the server, but `usePathname()` returns `/` (the browser URL) on the client after hydration. This caused `ConditionalThemeProvider` to match `pathname === "/"` → `forcedTheme="light"`, which overrode the blocking script and `DocsChrome` dark mode — explaining the persistent white header.
- **Fix**: Check `window.location.hostname` directly in `ConditionalThemeProvider` to detect docs domain and force dark theme, regardless of what `usePathname()` returns.
- No hydration mismatch: server forces dark via `/docs` pathname (from rewrite), client forces dark via hostname check — both paths yield `forcedTheme="dark"`.

## Test plan
- [ ] Visit `docs.ganamos.earth` — header should be dark immediately, no white flash
- [ ] Visit `docs.ganamos.earth` in incognito — same result
- [ ] Visit `ganamos.earth` homepage — should still be light mode
- [ ] Visit `ganamos.earth/auth/login` — should still be light mode
- [ ] Visit `ganamos.earth/dashboard` — should respect user theme preference


Made with [Cursor](https://cursor.com)