### PR TITLE
fix: show full header with nav items on docs.ganamos.earth

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -21,8 +21,11 @@ export function BottomNav() {
   // Before session is established, prefetch could cache a "redirect to login" response
   const canPrefetch = sessionLoaded && !!session
 
-  // Don't show bottom nav on home page, auth pages, public job posting page, post creation page, post detail page, withdraw page, deposit page, pet settings page, or satoshi-pet pages
-  if (pathname === "/" || pathname.startsWith("/auth") || pathname === "/new" || pathname === "/post/new" || pathname.startsWith("/post/") || pathname.startsWith("/wallet/withdraw") || pathname.startsWith("/wallet/deposit") || pathname === "/pet-settings" || pathname.startsWith("/satoshi-pet")) {
+  const isDocsDomain = typeof window !== 'undefined' &&
+    window.location.hostname === 'docs.ganamos.earth'
+
+  // Don't show bottom nav on home page, auth pages, public job posting page, post creation page, post detail page, withdraw page, deposit page, pet settings page, satoshi-pet pages, or docs subdomain
+  if (isDocsDomain || pathname === "/" || pathname.startsWith("/auth") || pathname === "/new" || pathname === "/post/new" || pathname.startsWith("/post/") || pathname.startsWith("/wallet/withdraw") || pathname.startsWith("/wallet/deposit") || pathname === "/pet-settings" || pathname.startsWith("/satoshi-pet")) {
     return null
   }
 

--- a/components/desktop-header.tsx
+++ b/components/desktop-header.tsx
@@ -29,8 +29,15 @@ declare global {
 
 export function DesktopHeader() {
   // ALL hooks must be called before any conditional returns (React rules)
-  const pathname = usePathname()
+  const rawPathname = usePathname()
   const router = useRouter()
+
+  // On docs.ganamos.earth, middleware rewrites / → /docs on the server, but
+  // usePathname() returns "/" on the client. Correct this so pathname-based
+  // checks (hide-on-home, search-bar visibility) behave correctly.
+  const isDocsDomain = typeof window !== 'undefined' &&
+    window.location.hostname === 'docs.ganamos.earth'
+  const pathname = isDocsDomain && rawPathname === '/' ? '/docs' : rawPathname
   // NotificationsProvider removed - pending requests feature disabled
   const hasPendingRequests = false
   const donationModal = useDonationModal() // May be undefined if provider not available
@@ -154,7 +161,7 @@ export function DesktopHeader() {
     <header className="fixed top-0 left-0 right-0 z-50 bg-white/95 dark:bg-background/95 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 hidden lg:block">
       <div className="max-w-[1800px] mx-auto px-6 h-16 flex items-center justify-between gap-4">
         {/* Left side - Logo */}
-        <Link href="/dashboard" className="flex items-center gap-2 flex-shrink-0">
+        <a href={isDocsDomain ? "https://www.ganamos.earth" : "/dashboard"} className="flex items-center gap-2 flex-shrink-0">
           <Image
             src="/favicon.png"
             alt="Ganamos"
@@ -165,7 +172,7 @@ export function DesktopHeader() {
           <span className="text-xl font-semibold text-gray-900 dark:text-white" style={{ fontFamily: 'Pacifico, cursive' }}>
             Ganamos
           </span>
-        </Link>
+        </a>
 
         {/* Center - Search Bar */}
         {(pathname === "/dashboard" || pathname.startsWith("/post/")) && (
@@ -377,42 +384,68 @@ export function DesktopHeader() {
             // Anonymous user view
             sessionLoaded && (
               <>
-                <Link 
-                  href="/map" 
+                <a 
+                  href={isDocsDomain ? "https://www.ganamos.earth/map" : "/map"}
                   className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
                 >
                   <MapPin className="w-4 h-4" />
                   Map
-                </Link>
-                <button
-                  onClick={() => {
-                    setAuthFeature('wallet')
-                    setShowAuthModal(true)
-                  }}
-                  className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
-                >
-                  <Wallet className="w-4 h-4" />
-                  Wallet
-                </button>
-                <button
-                  onClick={() => {
-                    setAuthFeature('profile')
-                    setShowAuthModal(true)
-                  }}
-                  className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
-                >
-                  <UserCircle className="w-4 h-4" />
-                  Profile
-                </button>
+                </a>
+                {isDocsDomain ? (
+                  <a
+                    href="https://www.ganamos.earth/wallet"
+                    className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                  >
+                    <Wallet className="w-4 h-4" />
+                    Wallet
+                  </a>
+                ) : (
+                  <button
+                    onClick={() => {
+                      setAuthFeature('wallet')
+                      setShowAuthModal(true)
+                    }}
+                    className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                  >
+                    <Wallet className="w-4 h-4" />
+                    Wallet
+                  </button>
+                )}
+                {isDocsDomain ? (
+                  <a
+                    href="https://www.ganamos.earth/profile"
+                    className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                  >
+                    <UserCircle className="w-4 h-4" />
+                    Profile
+                  </a>
+                ) : (
+                  <button
+                    onClick={() => {
+                      setAuthFeature('profile')
+                      setShowAuthModal(true)
+                    }}
+                    className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                  >
+                    <UserCircle className="w-4 h-4" />
+                    Profile
+                  </button>
+                )}
                 <Button 
                   variant="outline" 
-                  onClick={() => router.push('/auth/login')}
+                  onClick={() => {
+                    if (isDocsDomain) window.location.href = 'https://www.ganamos.earth/auth/login'
+                    else router.push('/auth/login')
+                  }}
                   className="h-9"
                 >
                   Log In
                 </Button>
                 <Button 
-                  onClick={() => router.push('/auth/register')}
+                  onClick={() => {
+                    if (isDocsDomain) window.location.href = 'https://www.ganamos.earth/auth/register'
+                    else router.push('/auth/register')
+                  }}
                   className="h-9"
                 >
                   Sign Up


### PR DESCRIPTION
## Summary

- **Root cause**: On `docs.ganamos.earth`, `usePathname()` returns `/` (browser URL) not `/docs` (middleware rewrite target). This matched `pathname === "/"` in the DesktopHeader's exclusion list, causing it to return `null` entirely — no logo, no nav items.
- **Fix**: Detect docs domain via `window.location.hostname` and correct the pathname from `/` to `/docs`. All nav links (Map, Wallet, Profile, Log In, Sign Up) point to `https://www.ganamos.earth` instead of relative paths. Logo links to main site. BottomNav hidden on docs domain (mobile nav not useful for API docs).

## Test plan
- [ ] Visit `docs.ganamos.earth` on desktop — should see full dark header with Ganamos logo, Map, Wallet, Profile, Log In, Sign Up
- [ ] Click Ganamos logo — should navigate to `www.ganamos.earth` (not `/dashboard` on docs domain)
- [ ] Click Map/Wallet/Profile/Log In/Sign Up — should navigate to `www.ganamos.earth/*`
- [ ] Visit `docs.ganamos.earth` on mobile — should NOT see bottom nav bar
- [ ] Visit `www.ganamos.earth` — header behavior unchanged (logo goes to /dashboard, etc.)
- [ ] Visit `www.ganamos.earth` homepage — header still hidden as expected


Made with [Cursor](https://cursor.com)