### PR TITLE
fix: preimage paste not captured on demo page

### DIFF
--- a/app/docs/demo/page.tsx
+++ b/app/docs/demo/page.tsx
@@ -345,7 +345,13 @@ export default function DemoPage() {
                 onChange={e => setPreimage(e.target.value)}
                 placeholder="e.g. 6496c2a5124bb7d849750a06..."
                 className="font-mono text-sm"
-                onPaste={() => setStep('preimage')}
+                onPaste={(e) => {
+                  const pasted = e.clipboardData.getData('text')
+                  if (pasted.trim()) {
+                    setPreimage(pasted.trim())
+                    setStep('preimage')
+                  }
+                }}
               />
             </div>
 
@@ -387,7 +393,7 @@ export default function DemoPage() {
               </div>
               <div className="flex items-start gap-2">
                 <span className="text-muted-foreground shrink-0 w-20">Preimage</span>
-                <span className="text-foreground font-mono text-xs">{preimage.slice(0, 16)}...{preimage.slice(-8)}</span>
+                <span className="text-foreground font-mono text-xs">{preimage.length > 24 ? `${preimage.slice(0, 16)}...${preimage.slice(-8)}` : preimage}</span>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Fix race condition where pasting a preimage on the Pay step would transition to the Prove step but lose the pasted value (onPaste unmounted the input before onChange could fire)
- Read pasted text directly from `clipboardData` so the value is captured before the step transition
- Guard against displaying a broken "..." when preimage is empty

## Test plan
- [ ] Go to demo page, fill in a job, get an invoice
- [ ] Paste a preimage into the input — should auto-advance to Prove step with the preimage value captured
- [ ] Click "Create Post" — should NOT show "Paste the preimage" error

Made with [Cursor](https://cursor.com)