### PR TITLE
fix: correct View Live Post URL on demo page

### DIFF
--- a/app/docs/demo/page.tsx
+++ b/app/docs/demo/page.tsx
@@ -430,7 +430,7 @@ export default function DemoPage() {
               </div>
 
               <a
-                href={`${BASE_URL}/issue/${postId}`}
+                href={`${BASE_URL}/post/${postId}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Summary
- Fix the "View Live Post" link to use `/post/{id}` instead of `/issue/{id}`, matching the actual Next.js route at `app/post/[id]/page.tsx`

## Test plan
- [ ] Complete the demo flow and click "View Live Post" — should navigate to the correct post page

Made with [Cursor](https://cursor.com)