### PR TITLE
fix: improve toast notification description text visibility

### DIFF
--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -17,13 +17,14 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-foreground/70",
+          description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
           success: "group-[.toaster]:bg-green-50 group-[.toaster]:text-green-900 group-[.toaster]:border-green-200 dark:group-[.toaster]:bg-green-950 dark:group-[.toaster]:text-green-100 dark:group-[.toaster]:border-green-800 [&_[data-description]]:!text-green-700 dark:[&_[data-description]]:!text-green-300",
           error: "group-[.toaster]:bg-red-50 group-[.toaster]:text-red-900 group-[.toaster]:border-red-200 dark:group-[.toaster]:bg-red-950 dark:group-[.toaster]:text-red-100 dark:group-[.toaster]:border-red-800 [&_[data-description]]:!text-red-700 dark:[&_[data-description]]:!text-red-300",
+          info: "[&_[data-description]]:!text-muted-foreground",
         },
       }}
       {...props}


### PR DESCRIPTION
## Summary
- Toast notification description text (the secondary line) was using `text-foreground/70` (70% opacity), making it barely readable against the white background
- Changed to `text-muted-foreground` for proper contrast while maintaining visual hierarchy
- Added `info` toast variant with matching description styling, consistent with existing `success` and `error` variants

## Test plan
- [ ] Verify toast description text is clearly readable on light and dark backgrounds
- [ ] Check success, error, and info toast variants all have visible descriptions

Made with [Cursor](https://cursor.com)