### PR TITLE
fix: include proof of completion in fix review emails and use hi-res placeholder logo

### DIFF
--- a/app/actions/post-actions.ts
+++ b/app/actions/post-actions.ts
@@ -27,8 +27,10 @@ async function sendFixSubmittedEmailsToGroupAdmins(params: {
   aiAnalysis?: string | null
   beforeImageUrl?: string | null
   afterImageUrl?: string | null
+  proofOfCompletionText?: string | null
+  fixerNote?: string | null
 }): Promise<void> {
-  const { adminSupabase, groupId, postOwnerId, issueTitle, fixerName, postId, aiAnalysis, beforeImageUrl, afterImageUrl } = params
+  const { adminSupabase, groupId, postOwnerId, issueTitle, fixerName, postId, aiAnalysis, beforeImageUrl, afterImageUrl, proofOfCompletionText, fixerNote } = params
   
   // Get all group admins except the post owner (they already got emailed)
   const { data: groupAdmins, error: adminsError } = await adminSupabase
@@ -62,7 +64,9 @@ async function sendFixSubmittedEmailsToGroupAdmins(params: {
           postId: postId,
           aiAnalysis: aiAnalysis,
           beforeImageUrl: beforeImageUrl,
-          afterImageUrl: afterImageUrl
+          afterImageUrl: afterImageUrl,
+          proofOfCompletionText: proofOfCompletionText,
+          fixerNote: fixerNote,
         })
         console.log(`Fix review email sent to group admin: ${profile.email}`)
       } catch (error) {
@@ -1028,7 +1032,9 @@ export async function submitAnonymousFixForReviewAction(
             postId: postId,
             aiAnalysis: aiAnalysis,
             beforeImageUrl: postData.image_url,
-            afterImageUrl: fixImageUrl
+            afterImageUrl: fixImageUrl,
+            proofOfCompletionText: fixProofText,
+            fixerNote: fixerNote,
           })
           const emailDuration = Date.now() - emailStartTime
           console.log(`[EMAIL FLOW] Anonymous fix email completed in ${emailDuration}ms, result:`, JSON.stringify(emailResult))
@@ -1051,7 +1057,9 @@ export async function submitAnonymousFixForReviewAction(
             postId: postId,
             aiAnalysis: aiAnalysis,
             beforeImageUrl: postData.image_url,
-            afterImageUrl: fixImageUrl
+            afterImageUrl: fixImageUrl,
+            proofOfCompletionText: fixProofText,
+            fixerNote: fixerNote,
           })
           console.log(`Fix review emails sent to group admins for group: ${postData.group_id}`)
         } catch (error) {
@@ -1266,7 +1274,9 @@ export async function submitLoggedInFixForReviewAction(params: {
             postId: postId,
             aiAnalysis: aiAnalysis,
             beforeImageUrl: postData.image_url,
-            afterImageUrl: fixImageUrl
+            afterImageUrl: fixImageUrl,
+            proofOfCompletionText: fixProofText,
+            fixerNote: fixerNote,
           })
           const emailDuration = Date.now() - emailStartTime
           console.log(`[EMAIL FLOW] Email completed in ${emailDuration}ms, result:`, JSON.stringify(emailResult))
@@ -1290,7 +1300,9 @@ export async function submitLoggedInFixForReviewAction(params: {
             postId: postId,
             aiAnalysis: aiAnalysis,
             beforeImageUrl: postData.image_url,
-            afterImageUrl: fixImageUrl
+            afterImageUrl: fixImageUrl,
+            proofOfCompletionText: fixProofText,
+            fixerNote: fixerNote,
           })
           console.log(`Fix review emails sent to group admins for group: ${postData.group_id}`)
         } catch (error) {

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -1940,7 +1940,7 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
               >
                 {post.has_image === false && !post.imageUrl && !post.image_url ? (
                   <div className="w-full h-full flex items-center justify-center bg-white dark:bg-gray-800">
-                    <Image src="/favicon.png" alt="Post" width={64} height={64} className="rounded-lg" />
+                    <Image src="/icon-512x512.png" alt="Post" width={64} height={64} className="rounded-lg" />
                   </div>
                 ) : (
                   <Image
@@ -1971,7 +1971,7 @@ export default function PostDetailPage({ params }: { params: { id: string } }) {
                 >
                   {post.has_image === false && !post.imageUrl && !post.image_url ? (
                     <div className="w-full h-full flex items-center justify-center bg-white dark:bg-gray-800">
-                      <Image src="/favicon.png" alt="Before" width={64} height={64} className="rounded-lg" />
+                      <Image src="/icon-512x512.png" alt="Before" width={64} height={64} className="rounded-lg" />
                     </div>
                   ) : (
                     <Image

--- a/components/map-modal.tsx
+++ b/components/map-modal.tsx
@@ -480,7 +480,7 @@ export function MapModal({ isOpen, onClose, posts, centerPost }: MapModalProps) 
 
                 <div className="flex gap-3">
                   <img
-                    src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/favicon.png' : '/placeholder.svg')}
+                    src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/icon-512x512.png' : '/placeholder.svg')}
                     alt="Issue"
                     className={`w-16 h-16 rounded-lg flex-shrink-0 ${selectedPost.has_image === false && !selectedPost.imageUrl && !selectedPost.image_url ? 'object-contain p-2 bg-white' : 'object-cover bg-gray-100'}`}
                   />

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -1237,7 +1237,7 @@ function MapViewComponent({
 
             <div className="flex gap-3">
               <img
-                src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/favicon.png' : '/placeholder.svg')}
+                src={selectedPost.imageUrl || selectedPost.image_url || (selectedPost.has_image === false ? '/icon-512x512.png' : '/placeholder.svg')}
                 alt="Issue"
                 className={`w-16 h-16 rounded-lg flex-shrink-0 ${selectedPost.has_image === false && !selectedPost.imageUrl && !selectedPost.image_url ? 'object-contain p-2 bg-white' : 'object-cover bg-gray-100'}`}
               />

--- a/lib/transaction-emails.ts
+++ b/lib/transaction-emails.ts
@@ -828,8 +828,10 @@ export async function sendFixSubmittedForReviewEmail(params: {
   aiAnalysis?: string | null
   beforeImageUrl?: string | null
   afterImageUrl?: string | null
+  proofOfCompletionText?: string | null
+  fixerNote?: string | null
 }) {
-  const { toEmail, userName, issueTitle, fixerName, date, postId, aiAnalysis, beforeImageUrl, afterImageUrl } = params
+  const { toEmail, userName, issueTitle, fixerName, date, postId, aiAnalysis, beforeImageUrl, afterImageUrl, proofOfCompletionText, fixerNote } = params
   
   // Build the review URL with review flag to trigger the review flow
   // Note: This is different from ?verify=true which opens the "Close Issue" dialog
@@ -997,6 +999,18 @@ export async function sendFixSubmittedForReviewEmail(params: {
                 </td>
               </tr>
             </table>
+          </div>
+          ` : ''}
+          ${proofOfCompletionText ? `
+          <div style="background-color: #f0fdf4; border-left: 4px solid #22c55e; padding: 15px; margin: 20px 0; border-radius: 6px;">
+            <h3 style="margin: 0 0 8px 0; font-size: 14px; font-weight: 600; color: #166534;">Proof of completion:</h3>
+            <p style="margin: 0; font-size: 14px; color: #15803d; line-height: 1.6; white-space: pre-line;">${proofOfCompletionText}</p>
+          </div>
+          ` : ''}
+          ${fixerNote ? `
+          <div style="background-color: #f9fafb; border-left: 4px solid #9ca3af; padding: 15px; margin: 20px 0; border-radius: 6px;">
+            <h3 style="margin: 0 0 8px 0; font-size: 14px; font-weight: 600; color: #374151;">Fixer's note:</h3>
+            <p style="margin: 0; font-size: 14px; color: #4b5563; line-height: 1.6; white-space: pre-line;">${fixerNote}</p>
           </div>
           ` : ''}
           <center>

--- a/tests/unit/actions/submit-anonymous-fix-action.test.ts
+++ b/tests/unit/actions/submit-anonymous-fix-action.test.ts
@@ -227,7 +227,9 @@ describe('submitAnonymousFixForReviewAction', () => {
         postId: postId,
         aiAnalysis: aiAnalysis,
         beforeImageUrl: testPost.image_url || undefined,
-        afterImageUrl: fixImageUrl
+        afterImageUrl: fixImageUrl,
+        proofOfCompletionText: null,
+        fixerNote: fixerNote,
       })
     })
 
@@ -510,7 +512,9 @@ describe('submitAnonymousFixForReviewAction', () => {
         postId: 'test-post-123',
         aiAnalysis: 'Medium confidence',
         beforeImageUrl: testPost.image_url || undefined,
-        afterImageUrl: 'https://example.com/fix.jpg'
+        afterImageUrl: 'https://example.com/fix.jpg',
+        proofOfCompletionText: null,
+        fixerNote: 'Fixed the pothole',
       })
     })
 


### PR DESCRIPTION
## Summary
- **Fix review emails now include proof of completion text and fixer's note** for imageless jobs (text-only fix submissions). Previously these fields were not passed to the email template, so the reviewer only saw "Submitted By" and "Date" with no context about the fix.
- **Replace fuzzy 48x48 favicon.png with 2048x2048 icon-512x512.png** for post placeholder images on the review page, map modal, and map view. The favicon was being rendered at 64x64, causing visible blurriness.

## Test plan
- [ ] Submit a fix for an imageless job with proof-of-completion text and verify the email includes the green "Proof of completion" section
- [ ] Submit a fix with a fixer's note and verify the email includes the gray "Fixer's note" section
- [ ] Verify before/after image emails still render correctly (no regression)
- [ ] Check placeholder logo on post detail page for imageless posts — should be crisp, not fuzzy
- [ ] Check placeholder logo in map modal and map view for imageless posts


Made with [Cursor](https://cursor.com)