### PR TITLE
fix: resolve race condition causing missing markers on globe view

### DIFF
--- a/components/globe-map-view.tsx
+++ b/components/globe-map-view.tsx
@@ -40,6 +40,7 @@ const GlobeMapViewComponent = ({
   const [isLoading, setIsLoading] = useState(true)
   const [Globe, setGlobe] = useState<any>(null)
   const [isVisible, setIsVisible] = useState(true)
+  const [globeReady, setGlobeReady] = useState(false)
   const wasRotatingBeforePause = useRef(false)
 
   // Load globe.gl dynamically (client-side only)
@@ -320,6 +321,7 @@ const GlobeMapViewComponent = ({
       })
 
     setIsLoading(false)
+    setGlobeReady(true)
 
     // Handle resize
     const handleResize = () => {
@@ -336,6 +338,7 @@ const GlobeMapViewComponent = ({
       if (globeRef.current) {
         globeRef.current._destructor?.()
         globeRef.current = null
+        setGlobeReady(false)
       }
     }
   }, [Globe]) // Only depend on Globe library loading
@@ -390,13 +393,13 @@ const GlobeMapViewComponent = ({
       .ringRepeatPeriod("repeatPeriod")
   }, [userLocation])
 
-  // Update points when posts change
+  // Update points when posts change or globe becomes ready
   useEffect(() => {
     if (globeRef.current && postsWithLocation.length > 0) {
       globeRef.current.pointsData(postsWithLocation)
       globeRef.current.htmlElementsData(postsWithLocation)
     }
-  }, [postsWithLocation])
+  }, [postsWithLocation, globeReady])
 
   // Animate to searched location when it changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed a race condition where Bitcoin markers were not appearing on the globe view when switching from the flat map
- The marker data effect fired before the Globe library finished loading asynchronously, so `globeRef.current` was null and markers were never applied
- Added a `globeReady` state flag that triggers the data effect to re-run once the globe instance is created

## Test plan
- [ ] Open the dashboard with the flat map view
- [ ] Switch to globe view and verify Bitcoin markers appear
- [ ] Switch back to flat map and then to globe again -- markers should still appear
- [ ] Verify markers update when new posts are created

Made with [Cursor](https://cursor.com)