### PR TITLE
fix: make globe spin consistently left-to-right on load

### DIFF
--- a/components/globe-map-view.tsx
+++ b/components/globe-map-view.tsx
@@ -151,7 +151,7 @@ const GlobeMapViewComponent = ({
     const height = container.clientHeight
 
     // Create globe instance
-    const globe = new Globe(container)
+    const globe = new Globe(container, { animateIn: false })
       .width(width)
       .height(height)
       .backgroundColor("#020817") // Matches app dark theme background


### PR DESCRIPTION
## Summary
- Disable globe.gl's built-in `animateIn` intro animation which rotates right-to-left on load, conflicting with the `autoRotate` left-to-right steady-state spin
- Globe now appears in place and only ever spins left-to-right

## Test plan
- [ ] Open the globe map view and verify the globe no longer spins right-to-left during initial load
- [ ] Confirm the globe spins left-to-right consistently from the moment it appears
- [ ] Verify user interaction (drag/zoom) still pauses and resumes auto-rotation correctly


Made with [Cursor](https://cursor.com)