### PR TITLE
fix: prevent map from zooming out beyond screen bounds

### DIFF
--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -661,9 +661,10 @@ function MapViewComponent({
       // Create map instance with all controls disabled
       const map = new window.google.maps.Map(mapRef.current, {
         center: defaultCenter,
-        zoom: 2, // Start with a low zoom, will be adjusted by bounds if provided
+        zoom: 3,
+        minZoom: 3,
         mapTypeId: window.google.maps.MapTypeId.ROADMAP,
-        disableDefaultUI: true, // Disable all default UI controls
+        disableDefaultUI: true,
         zoomControl: false,
         mapTypeControl: false,
         scaleControl: false,
@@ -671,8 +672,17 @@ function MapViewComponent({
         rotateControl: false,
         fullscreenControl: false,
         gestureHandling: "greedy",
-        clickableIcons: false, // Disable native POI info windows
-        keyboardShortcuts: false, // Disable keyboard shortcuts
+        clickableIcons: false,
+        keyboardShortcuts: false,
+        restriction: {
+          latLngBounds: {
+            north: 85,
+            south: -85,
+            east: 180,
+            west: -180,
+          },
+          strictBounds: true,
+        },
       })
 
 


### PR DESCRIPTION
## Summary
- Adds `minZoom: 3` to the main map view to prevent users from zooming out far enough to see blank gray space above/below the map
- Adds `restriction` with `strictBounds: true` to constrain panning to valid Mercator projection bounds (±85° latitude)
- Bumps initial zoom from 2 to 3 so the map fills the viewport on first load when no location is selected

## Test plan
- [ ] Load the app on desktop without a saved location — map should fill the screen with no gray space
- [ ] Try zooming out as far as possible — should stop at zoom level 3
- [ ] Try panning up/down past the poles — should be constrained
- [ ] Verify normal zoom/pan behavior at city level is unaffected

Made with [Cursor](https://cursor.com)