### PR TITLE
Fix post creation with an atomic database transaction

### DIFF
--- a/app/actions/post-actions.ts
+++ b/app/actions/post-actions.ts
@@ -1444,9 +1444,22 @@ export async function claimAnonymousRewardAction(
 export async function createPostWithRewardAction(params: {
   postId: string
   userId: string
+  title: string
+  description: string
+  imageUrl?: string | null
+  hasImage?: boolean
+  location?: string | null
+  latitude?: number | null
+  longitude?: number | null
   reward: number
+  groupId?: string | null
+  assignedTo?: string | null
+  city?: string | null
+  createdBy?: string | null
+  createdByAvatar?: string | null
+  expiresAt?: string | null
   memo?: string
-}): Promise<{ success: boolean; error?: string; transactionId?: string }> {
+}): Promise<{ success: boolean; error?: string; transactionId?: string; newBalance?: number }> {
   'use server'
   
   try {
@@ -1484,99 +1497,50 @@ export async function createPostWithRewardAction(params: {
       return { success: false, error: 'Unauthorized: Cannot modify another user\'s balance' }
     }
 
-    if (!postId || !userId || reward <= 0) {
+    if (!postId || !userId || !params.title.trim() || !params.description.trim() || reward < 0) {
       return { success: false, error: 'Invalid parameters' }
     }
 
-    // SAFETY: Check reward cap (blocks at hard limit)
-    const rewardCapCheck = await checkPostRewardCap(userId, reward)
-    if (!rewardCapCheck.allowed) {
-      console.warn(`[Safety Caps] Post reward blocked: ${reward} sats exceeds hard cap for user ${userId}`)
-      return { success: false, error: rewardCapCheck.message || 'Post reward exceeds maximum allowed amount.' }
-    }
-    if (rewardCapCheck.capLevel !== 'none') {
-      console.log(`[Safety Caps] Post reward cap ${rewardCapCheck.capLevel} triggered for user ${userId}`)
-    }
-
-    // IMPORTANT: Use admin supabase for transaction creation and balance updates
-    // The prevent_direct_balance_update trigger only allows service_role to modify balances
-    // All transaction creation must go through service_role
-    const adminSupabase = createServerSupabaseClient({
-      supabaseKey: process.env.SUPABASE_SECRET_API_KEY,
+    const { data, error } = await supabase.rpc('create_post_atomic', {
+      p_post_id: postId,
+      p_user_id: userId,
+      p_title: params.title,
+      p_description: params.description,
+      p_image_url: params.imageUrl ?? null,
+      p_has_image: params.hasImage ?? Boolean(params.imageUrl),
+      p_location: params.location ?? null,
+      p_latitude: params.latitude ?? null,
+      p_longitude: params.longitude ?? null,
+      p_reward: reward,
+      p_group_id: params.groupId ?? null,
+      p_assigned_to: params.assignedTo ?? null,
+      p_city: params.city ?? null,
+      p_created_by: params.createdBy ?? null,
+      p_created_by_avatar: params.createdByAvatar ?? null,
+      p_expires_at: params.expiresAt ?? null,
+      p_memo: memo ?? null,
     })
 
-    // Get current balance to verify sufficient funds
-    const { data: profile, error: profileError } = await adminSupabase
-      .from('profiles')
-      .select('balance')
-      .eq('id', userId)
-      .single()
-
-    if (profileError || !profile) {
-      return { success: false, error: 'User profile not found' }
+    if (error) {
+      console.error('Atomic post creation failed:', error)
+      return { success: false, error: error.message || 'Failed to create post' }
     }
 
-    if (profile.balance < reward) {
-      return { success: false, error: 'Insufficient balance' }
+    const result = data as unknown as {
+      success: boolean
+      transaction_id?: string | null
+      new_balance?: number
     }
-
-    // Create transaction record for the post reward deduction
-    const { data: transaction, error: txError } = await adminSupabase
-      .from('transactions')
-      .insert({
-        user_id: userId,
-        type: 'internal', // Post reward is an internal transaction
-        amount: -reward, // Negative because it's a deduction
-        status: 'completed',
-        memo: memo || `Post reward for issue`,
-      })
-      .select('id')
-      .single()
-
-    if (txError || !transaction) {
-      console.error('Error creating post reward transaction:', txError)
-      return { success: false, error: 'Failed to create transaction' }
-    }
-
-    // Update balance atomically
-    const newBalance = profile.balance - reward
-    const { error: balanceError } = await adminSupabase
-      .from('profiles')
-      .update({
-        balance: newBalance,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', userId)
-
-    if (balanceError) {
-      console.error('Error updating balance after post reward transaction:', balanceError)
-      // Transaction was created but balance update failed - this is inconsistent
-      // In a real scenario, we'd want to rollback or handle this better
-      return { success: false, error: 'Transaction created but balance update failed' }
-    }
-
-    // Create activity for the post reward
-    await adminSupabase.from('activities').insert({
-      id: uuidv4(),
-      user_id: userId,
-      type: 'post',
-      related_id: postId,
-      related_table: 'posts',
-      timestamp: new Date().toISOString(),
-      metadata: { 
-        title: memo || 'Post created',
-        reward: reward,
-        transaction_id: transaction.id
-      },
-    })
-
-    console.log(`Post reward transaction created: ${transaction.id} for post ${postId}, ${reward} sats deducted`)
     
     // SECURITY: Send SMS alert for large post bounties
-    alertLargePostBounty(userId, reward, memo)
+    if (reward > 0) alertLargePostBounty(userId, reward, memo)
       .catch(err => console.error("[Security Alert] SMS for large bounty failed:", err))
     
-    return { success: true, transactionId: transaction.id }
+    return {
+      success: result.success,
+      transactionId: result.transaction_id ?? undefined,
+      newBalance: result.new_balance,
+    }
   } catch (error) {
     console.error('Error in createPostWithRewardAction:', error)
     return {

--- a/app/post/new/page.tsx
+++ b/app/post/new/page.tsx
@@ -679,79 +679,34 @@ export default function NewPostPage() {
         console.log("✅ Image uploaded successfully")
       }
 
-      const postDataForSupabase = {
-        id: postId,
-        user_id: activeUserId || user!.id,
-        created_by: profile!.name,
-        created_by_avatar: profile!.avatar_url,
+      const { createPostWithRewardAction } = await import("@/app/actions/post-actions")
+      const result = await createPostWithRewardAction({
+        postId,
+        userId: activeUserId || user!.id,
         title: description.substring(0, 50),
         description,
-        image_url: finalImageUrl,
-        has_image: finalImageUrl != null,
-        location: currentLocation?.name || null, // Use geocoded name
+        imageUrl: finalImageUrl,
+        hasImage: finalImageUrl != null,
+        location: currentLocation?.name || null,
         latitude: currentLocation?.lat || null,
         longitude: currentLocation?.lng || null,
         reward,
-        claimed: false,
-        fixed: false,
-        created_at: now.toISOString(),
-        group_id: assignedTo ? null : selectedGroupId, // If assigned to person, no group
-        assigned_to: assignedTo, // Individual assignment
-        city: currentLocation?.displayName || currentLocation?.name || null, // Use displayName or fallback to name
-        is_anonymous: false,
-        expires_at: expiresAt ? expiresAt.toISOString() : null,
+        groupId: assignedTo ? null : selectedGroupId,
+        assignedTo,
+        city: currentLocation?.displayName || currentLocation?.name || null,
+        createdBy: profile!.name,
+        createdByAvatar: profile!.avatar_url,
+        expiresAt: expiresAt ? expiresAt.toISOString() : null,
+        memo: `Post reward for: ${description.substring(0, 50)}`,
+      })
+
+      if (!result.success) {
+        console.error("Atomic post creation failed:", result.error)
+        toast.error("Error", { description: result.error || "Post was not created." })
+        return
       }
 
-      if (supabase) {
-        const { error: insertError } = await supabase.from("posts").insert(postDataForSupabase)
-        if (insertError) {
-          console.error("Error saving post to Supabase:", insertError)
-          throw insertError
-        }
-        
-        // Only insert activity for posts WITHOUT rewards (server action will handle posts with rewards)
-        if (reward === 0) {
-          try {
-            await supabase.from("activities").insert({
-              id: uuidv4(),
-              user_id: activeUserId || user!.id,
-              type: "post",
-              related_id: postId,
-              related_table: "posts",
-              timestamp: now.toISOString(),
-              metadata: { title: description.substring(0, 50) },
-            })
-          } catch (activityError) {
-            console.error("Error inserting activity for new post:", activityError)
-          }
-        }
-      }
-
-      // If post has a reward, create a transaction and update balance atomically
-      // This also creates the activity with reward info
-      if (profile && reward > 0) {
-        const { createPostWithRewardAction } = await import("@/app/actions/post-actions")
-        const result = await createPostWithRewardAction({
-          postId,
-          userId: activeUserId || user!.id,
-          reward,
-          memo: `Post reward for: ${description.substring(0, 50)}`
-        })
-        
-        if (!result.success) {
-          console.error("Error creating post reward transaction:", result.error)
-          // SECURITY: Delete the post if reward deduction fails — an unfunded
-          // reward post can be exploited to mint sats when the fix is approved.
-          if (supabase) {
-            await supabase.from("posts").delete().eq("id", postId)
-          }
-          toast.error("Error", { description: result.error || "Failed to reserve reward. Post was not created." })
-          return
-        } else {
-          // Refresh profile to get updated balance (action already updated it in DB)
-          await refreshProfile()
-        }
-      }
+      await refreshProfile()
 
       // Send email notification if assigned to a specific person
       if (assignedTo && assignedToProfile) {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -585,6 +585,35 @@ export interface Database {
         }
       }
     }
+    Functions: {
+      create_post_atomic: {
+        Args: {
+          p_post_id: string
+          p_user_id: string
+          p_title: string
+          p_description: string
+          p_image_url?: string | null
+          p_has_image?: boolean
+          p_location?: string | null
+          p_latitude?: number | null
+          p_longitude?: number | null
+          p_reward?: number
+          p_group_id?: string | null
+          p_assigned_to?: string | null
+          p_city?: string | null
+          p_created_by?: string | null
+          p_created_by_avatar?: string | null
+          p_expires_at?: string | null
+          p_memo?: string | null
+        }
+        Returns: {
+          success: boolean
+          post_id: string
+          transaction_id: string | null
+          new_balance: number
+        }
+      }
+    }
   }
 }
 

--- a/supabase/migrations/20260803080000_atomic_create_post.sql
+++ b/supabase/migrations/20260803080000_atomic_create_post.sql
@@ -1,0 +1,172 @@
+-- Canonical atomic post creation for web and native clients.
+-- Creates the post, reserves any reward, records the ledger entry, and creates
+-- activity in one database transaction.
+
+CREATE OR REPLACE FUNCTION public.create_post_atomic(
+  p_post_id UUID,
+  p_user_id UUID,
+  p_title TEXT,
+  p_description TEXT,
+  p_image_url TEXT DEFAULT NULL,
+  p_has_image BOOLEAN DEFAULT FALSE,
+  p_location TEXT DEFAULT NULL,
+  p_latitude DOUBLE PRECISION DEFAULT NULL,
+  p_longitude DOUBLE PRECISION DEFAULT NULL,
+  p_reward INTEGER DEFAULT 0,
+  p_group_id UUID DEFAULT NULL,
+  p_assigned_to UUID DEFAULT NULL,
+  p_city TEXT DEFAULT NULL,
+  p_created_by TEXT DEFAULT NULL,
+  p_created_by_avatar TEXT DEFAULT NULL,
+  p_expires_at TIMESTAMPTZ DEFAULT NULL,
+  p_memo TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor_id UUID := auth.uid();
+  v_balance INTEGER;
+  v_new_balance INTEGER;
+  v_transaction_id UUID;
+  v_reward_allowed BOOLEAN;
+  v_live_allowed BOOLEAN;
+BEGIN
+  IF v_actor_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Not authenticated';
+  END IF;
+
+  IF p_post_id IS NULL OR p_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Post ID and user ID are required';
+  END IF;
+
+  IF v_actor_id <> p_user_id AND NOT EXISTS (
+    SELECT 1 FROM public.connected_accounts ca
+    WHERE ca.primary_user_id = v_actor_id AND ca.connected_user_id = p_user_id
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Unauthorized account';
+  END IF;
+
+  IF NULLIF(BTRIM(p_title), '') IS NULL OR NULLIF(BTRIM(p_description), '') IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Title and description are required';
+  END IF;
+
+  IF p_reward < 0 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Reward cannot be negative';
+  END IF;
+
+  SELECT allowed INTO v_live_allowed FROM public.check_live_posts_cap() LIMIT 1;
+  IF COALESCE(v_live_allowed, TRUE) = FALSE THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0001', MESSAGE = 'The live post limit has been reached';
+  END IF;
+
+  IF p_reward > 0 THEN
+    SELECT allowed INTO v_reward_allowed
+    FROM public.check_post_reward_cap(p_user_id, p_reward) LIMIT 1;
+    IF COALESCE(v_reward_allowed, TRUE) = FALSE THEN
+      RAISE EXCEPTION USING ERRCODE = 'P0001', MESSAGE = 'Post reward exceeds the maximum allowed amount';
+    END IF;
+
+    SELECT balance INTO v_balance
+    FROM public.profiles WHERE id = p_user_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION USING ERRCODE = 'P0002', MESSAGE = 'User profile not found';
+    END IF;
+    IF v_balance < p_reward THEN
+      RAISE EXCEPTION USING ERRCODE = 'P0001', MESSAGE = 'Insufficient balance';
+    END IF;
+    v_new_balance := v_balance - p_reward;
+  ELSE
+    SELECT balance INTO v_balance FROM public.profiles WHERE id = p_user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION USING ERRCODE = 'P0002', MESSAGE = 'User profile not found';
+    END IF;
+    v_new_balance := v_balance;
+  END IF;
+
+  INSERT INTO public.posts (
+    id, user_id, created_by, created_by_avatar, title, description,
+    image_url, has_image, location, latitude, longitude, reward,
+    claimed, fixed, group_id, assigned_to, city, is_anonymous, expires_at
+  ) VALUES (
+    p_post_id, p_user_id, p_created_by, p_created_by_avatar,
+    BTRIM(p_title), BTRIM(p_description), p_image_url, p_has_image,
+    NULLIF(BTRIM(p_location), ''), p_latitude, p_longitude, p_reward,
+    FALSE, FALSE, p_group_id, p_assigned_to, NULLIF(BTRIM(p_city), ''),
+    FALSE, p_expires_at
+  );
+
+  IF p_reward > 0 THEN
+    INSERT INTO public.transactions (user_id, type, amount, status, memo)
+    VALUES (p_user_id, 'internal', -p_reward, 'completed',
+      COALESCE(NULLIF(BTRIM(p_memo), ''), 'Post reward for issue'))
+    RETURNING id INTO v_transaction_id;
+
+    UPDATE public.profiles
+    SET balance = v_new_balance, updated_at = NOW()
+    WHERE id = p_user_id AND balance = v_balance;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION USING ERRCODE = '40001', MESSAGE = 'Balance changed concurrently; please retry';
+    END IF;
+  END IF;
+
+  INSERT INTO public.activities (
+    id, user_id, type, related_id, related_table, timestamp, metadata
+  ) VALUES (
+    gen_random_uuid(), p_user_id, 'post', p_post_id, 'posts', NOW(),
+    jsonb_strip_nulls(jsonb_build_object(
+      'title', COALESCE(NULLIF(BTRIM(p_memo), ''), BTRIM(p_title)),
+      'reward', p_reward, 'transaction_id', v_transaction_id
+    ))
+  );
+
+  RETURN jsonb_build_object(
+    'success', TRUE, 'post_id', p_post_id,
+    'transaction_id', v_transaction_id, 'new_balance', v_new_balance
+  );
+END;
+$$;
+
+-- Preserve the client-side balance guard while allowing audited, owner-run
+-- SECURITY DEFINER functions to perform trusted balance mutations. Direct
+-- authenticated updates still run as `authenticator` and remain blocked.
+CREATE OR REPLACE FUNCTION public.prevent_direct_balance_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF OLD.balance IS NOT DISTINCT FROM NEW.balance
+     AND OLD.pet_coins IS NOT DISTINCT FROM NEW.pet_coins THEN
+    RETURN NEW;
+  END IF;
+
+  IF current_user IN ('postgres', 'service_role')
+     OR COALESCE(NULLIF(current_setting('request.jwt.claims', TRUE), '')::jsonb->>'role', '') = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE WARNING 'SECURITY: Blocked balance update. User: %, Attempted: % -> %',
+    auth.uid(), OLD.balance, NEW.balance;
+  NEW.balance := OLD.balance;
+  NEW.pet_coins := OLD.pet_coins;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_post_atomic(
+  UUID, UUID, TEXT, TEXT, TEXT, BOOLEAN, TEXT, DOUBLE PRECISION,
+  DOUBLE PRECISION, INTEGER, UUID, UUID, TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.create_post_atomic(
+  UUID, UUID, TEXT, TEXT, TEXT, BOOLEAN, TEXT, DOUBLE PRECISION,
+  DOUBLE PRECISION, INTEGER, UUID, UUID, TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT
+) TO authenticated;
+
+COMMENT ON FUNCTION public.create_post_atomic(
+  UUID, UUID, TEXT, TEXT, TEXT, BOOLEAN, TEXT, DOUBLE PRECISION,
+  DOUBLE PRECISION, INTEGER, UUID, UUID, TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT
+) IS 'Atomically creates a post and reserves its reward for the authenticated user or an authorized connected account.';

--- a/tests/unit/actions/post-actions.test.ts
+++ b/tests/unit/actions/post-actions.test.ts
@@ -710,9 +710,8 @@ describe('createPostWithRewardAction', () => {
     vi.useRealTimers()
   })
 
-  describe('Admin Client Usage (Critical for RLS bypass)', () => {
-    it('should use admin client with service role key for transaction and balance operations', async () => {
-      // ARRANGE - Create separate mock clients for user session and admin
+  describe('Canonical atomic RPC', () => {
+    it('should use the authenticated client to call the atomic post function', async () => {
       const mockUserClient: any = {
         auth: {
           getSession: vi.fn().mockResolvedValue({
@@ -740,54 +739,19 @@ describe('createPostWithRewardAction', () => {
           }
           throw new Error(`User client should not access table: ${table}`)
         }),
-      }
-
-      const mockAdminClient: any = {
-        from: vi.fn((table: string) => {
-          if (table === 'profiles') {
-            return {
-              select: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  single: vi.fn().mockResolvedValue({ 
-                    data: { balance: 5000 }, 
-                    error: null 
-                  }),
-                })),
-              })),
-              update: vi.fn(() => ({
-                eq: vi.fn().mockResolvedValue({ data: null, error: null }),
-              })),
-            }
-          }
-          if (table === 'transactions') {
-            return {
-              insert: vi.fn(() => ({
-                select: vi.fn(() => ({
-                  single: vi.fn().mockResolvedValue({ 
-                    data: { id: TEST_TX_ID }, 
-                    error: null 
-                  }),
-                })),
-              })),
-            }
-          }
-          if (table === 'activities') {
-            return {
-              insert: vi.fn().mockResolvedValue({ data: null, error: null }),
-            }
-          }
-          throw new Error(`Unexpected table: ${table}`)
+        rpc: vi.fn().mockResolvedValue({
+          data: { success: true, transaction_id: TEST_TX_ID, new_balance: 4000 },
+          error: null,
         }),
       }
-
-      vi.mocked(createServerSupabaseClient)
-        .mockReturnValueOnce(mockUserClient)  // First call: user session for auth
-        .mockReturnValueOnce(mockAdminClient) // Second call: admin client for DB ops
+      vi.mocked(createServerSupabaseClient).mockReturnValue(mockUserClient)
 
       // ACT
       const result = await createPostWithRewardAction({
         postId: TEST_POST_ID,
         userId: TEST_USER_ID,
+        title: 'Test post',
+        description: 'Test post description',
         reward: TEST_REWARD,
         memo: TEST_MEMO,
       })
@@ -796,21 +760,12 @@ describe('createPostWithRewardAction', () => {
       expect(result.success).toBe(true)
       expect(result.transactionId).toBe(TEST_TX_ID)
 
-      // Verify createServerSupabaseClient was called twice
-      expect(createServerSupabaseClient).toHaveBeenCalledTimes(2)
-
-      // First call should be with cookie store (user session for auth check)
-      expect(createServerSupabaseClient).toHaveBeenNthCalledWith(1, expect.any(Object))
-
-      // Second call should be with service role key (admin client for DB operations)
-      expect(createServerSupabaseClient).toHaveBeenNthCalledWith(2, {
-        supabaseKey: process.env.SUPABASE_SECRET_API_KEY,
-      })
-
-      // Verify admin client was used for sensitive operations
-      expect(mockAdminClient.from).toHaveBeenCalledWith('profiles')
-      expect(mockAdminClient.from).toHaveBeenCalledWith('transactions')
-      expect(mockAdminClient.from).toHaveBeenCalledWith('activities')
+      expect(createServerSupabaseClient).toHaveBeenCalledTimes(1)
+      expect(mockUserClient.rpc).toHaveBeenCalledWith('create_post_atomic', expect.objectContaining({
+        p_post_id: TEST_POST_ID,
+        p_user_id: TEST_USER_ID,
+        p_reward: TEST_REWARD,
+      }))
     })
 
     it('should reject if user is not authenticated', async () => {
@@ -830,6 +785,8 @@ describe('createPostWithRewardAction', () => {
       const result = await createPostWithRewardAction({
         postId: TEST_POST_ID,
         userId: TEST_USER_ID,
+        title: 'Test post',
+        description: 'Test post description',
         reward: TEST_REWARD,
       })
 
@@ -873,6 +830,8 @@ describe('createPostWithRewardAction', () => {
       const result = await createPostWithRewardAction({
         postId: TEST_POST_ID,
         userId: TEST_USER_ID,
+        title: 'Test post',
+        description: 'Test post description',
         reward: TEST_REWARD,
       })
 
@@ -910,32 +869,18 @@ describe('createPostWithRewardAction', () => {
         }),
       }
 
-      const mockAdminClient: any = {
-        from: vi.fn((table: string) => {
-          if (table === 'profiles') {
-            return {
-              select: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  single: vi.fn().mockResolvedValue({ 
-                    data: { balance: 500 }, // Less than reward
-                    error: null 
-                  }),
-                })),
-              })),
-            }
-          }
-          return {}
-        }),
-      }
-
-      vi.mocked(createServerSupabaseClient)
-        .mockReturnValueOnce(mockUserClient)
-        .mockReturnValueOnce(mockAdminClient)
+      mockUserClient.rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'Insufficient balance' },
+      })
+      vi.mocked(createServerSupabaseClient).mockReturnValue(mockUserClient)
 
       // ACT
       const result = await createPostWithRewardAction({
         postId: TEST_POST_ID,
         userId: TEST_USER_ID,
+        title: 'Test post',
+        description: 'Test post description',
         reward: TEST_REWARD, // 1000 > 500
       })
 


### PR DESCRIPTION
## Summary

- create posts, reserve rewards, record transactions, and add activity in one database transaction
- route both zero-reward and rewarded posts through the authenticated atomic RPC
- enforce authorization, balance locking, reward caps, and RPC permissions in PostgreSQL
- update database types and focused unit tests

## Database rollout

The included migration has already been applied and verified on both `ganamos-staging` and production `ganamos`. Both migration ledgers record `20260803080000`.

## Validation

- `npm test -- tests/unit/actions/post-actions.test.ts` — 39/39 passed
- `git diff --check` — passed
- `npx tsc --noEmit` — repository-wide check remains blocked by pre-existing typing errors in unrelated Lightning, Nostr, API, and legacy test code; no new errors were reported at the changed atomic-post lines
