### PR TITLE
Fix Supabase CI setup and E2E database access

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Keep CI reproducible and avoid a rate-limited "latest" lookup.
+          version: 2.111.0
 
       - name: Install dependencies
         run: npm ci
@@ -70,8 +71,13 @@ jobs:
           
           # Export to GITHUB_ENV for subsequent steps
           echo "SUPABASE_URL=$SUPABASE_URL" >> $GITHUB_ENV
-          echo "SUPABASE_ANON_KEY=$ANON_KEY" >> $GITHUB_ENV
-          echo "SUPABASE_SERVICE_KEY=$SERVICE_ROLE_KEY" >> $GITHUB_ENV
+          # CLI versions expose either legacy JWT names or the newer key names.
+          SUPABASE_ANON_KEY="${ANON_KEY:-$PUBLISHABLE_KEY}"
+          SUPABASE_SERVICE_KEY="${SERVICE_ROLE_KEY:-$SECRET_KEY}"
+          test -n "$SUPABASE_ANON_KEY"
+          test -n "$SUPABASE_SERVICE_KEY"
+          echo "SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY" >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_KEY=$SUPABASE_SERVICE_KEY" >> $GITHUB_ENV
           
           echo "Credentials exported successfully"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pin this so setup does not call the GitHub releases API to resolve
+          # "latest" (which is rate-limited on hosted runners).
+          version: 2.111.0
 
       - name: Start Supabase
         run: |
@@ -100,4 +102,4 @@ jobs:
 
       - name: Stop Supabase
         if: always()
-        run: supabase stop
+        run: command -v supabase >/dev/null && supabase stop || true

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -609,3 +609,39 @@ END $$;
 
 COMMENT ON TABLE donation_pools IS 'Seeded with donation pools for cities, countries, and global';
 COMMENT ON TABLE bitcoin_prices IS 'Seeded with sample Bitcoin prices for testing';
+
+-- Local Supabase API privileges. Production projects receive these grants when
+-- they are created, but a database rebuilt solely from this repository's old
+-- migrations does not. RLS remains the authorization boundary.
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+
+-- Avoid recursive evaluation of group_members while preserving the original
+-- rule: users may see their own row and members of groups they belong to.
+CREATE OR REPLACE FUNCTION public.is_approved_group_member(target_group_id uuid, target_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.group_members
+    WHERE group_id = target_group_id
+      AND user_id = target_user_id
+      AND status = 'approved'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_approved_group_member(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_approved_group_member(uuid, uuid)
+  TO anon, authenticated, service_role;
+
+DROP POLICY IF EXISTS "Users can view group members of their groups" ON public.group_members;
+CREATE POLICY "Users can view group members of their groups" ON public.group_members
+  FOR SELECT USING (
+    user_id = auth.uid()
+    OR public.is_approved_group_member(group_id, auth.uid())
+  );


### PR DESCRIPTION
## Summary
- pin Supabase CLI 2.111.0 to avoid rate-limited latest-release resolution
- support both legacy and current local Supabase credential names
- restore standard local API grants during seeding
- replace the recursive group-members SELECT policy in the local test database
- make cleanup safe when CLI installation fails

## Why
The failures after #127 were CI infrastructure failures: the Tests workflow could not resolve the latest CLI, while integration/E2E runs rebuilt a local database without API grants and hit a recursive group-members policy. The missing grants also prevented mock-login profile setup and deposit invoice persistence, causing the Bitcoin invoice timeouts.

## Validation
- diff/whitespace check passes
- Supabase CLI 2.111.0 resolves successfully
- full unit run: 1,849 passed; 40 pre-existing local geocoding failures caused by Node localStorage configuration (the GitHub unit job previously passed)
- local DB/E2E validation deferred to GitHub Actions because Docker Desktop is not running on this Mac

This changes only CI workflows and local Supabase seed behavior; it does not add or apply a production migration.